### PR TITLE
feat: support multiple prefixes and prefix auto-discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ docker compose up -d
 | --------------------- | ----------------------------------------- | ------------------------ |
 | `REDIS_URL`           | Redis connection URL                      | `redis://localhost:6379` |
 | `PORT`                | Port to run the dashboard on              | `4000`                   |
+| `REDIS_PREFIX`        | Comma-separated key prefixes              | auto-discover all        |
 | `BULLSTUDIO_USERNAME` | Password for HTTP Basic Auth (production) | `bullstudio`             |
 | `BULLSTUDIO_PASSWORD` | Password for HTTP Basic Auth (production) | (none)                   |
 
@@ -151,14 +152,15 @@ bullstudio [options]
 
 ### Options
 
-| Option              | Short | Description                                    | Default                  |
-| ------------------- | ----- | ---------------------------------------------- | ------------------------ |
-| `--redis <url>`     | `-r`  | Redis connection URL                           | `redis://localhost:6379` |
-| `--port <port>`     | `-p`  | Port to run the dashboard on                   | `4000`                   |
-| `--username <user>` |       | Username for HTTP Basic Auth (production only) | `bullstudio`             |
-| `--password <pass>` |       | Password for HTTP Basic Auth (production only) | (none)                   |
-| `--no-open`         |       | Don't open browser automatically               | Opens browser            |
-| `--help`            | `-h`  | Show help message                              |                          |
+| Option                 | Short | Description                                    | Default                  |
+| ---------------------- | ----- | ---------------------------------------------- | ------------------------ |
+| `--redis <url>`        | `-r`  | Redis connection URL                           | `redis://localhost:6379` |
+| `--port <port>`        | `-p`  | Port to run the dashboard on                   | `4000`                   |
+| `--prefix <prefixes>`  |       | Comma-separated key prefixes                   | auto-discover all        |
+| `--username <user>`    |       | Username for HTTP Basic Auth (production only) | `bullstudio`             |
+| `--password <pass>`    |       | Password for HTTP Basic Auth (production only) | (none)                   |
+| `--no-open`            |       | Don't open browser automatically               | Opens browser            |
+| `--help`               | `-h`  | Show help message                              |                          |
 
 ---
 
@@ -198,6 +200,21 @@ bullstudio -r redis://username:password@myhost.com:6379
 
 ```bash
 bullstudio --no-open
+```
+
+### Multiple prefixes
+
+By default bullstudio auto-discovers all prefixes in Redis.
+To restrict to specific prefixes:
+
+```bash
+bullstudio --prefix stage,stage2
+```
+
+Or via the environment variable:
+
+```bash
+REDIS_PREFIX=stage,stage2 bullstudio
 ```
 
 ### Combine options
@@ -330,7 +347,7 @@ docker run -d -p 6379:6379 redis
 bullstudio discovers queues by scanning for BullMQ metadata keys in Redis. Make sure:
 1. Your application has created at least one queue
 2. You're connecting to the correct Redis instance
-3. If using a prefix other than `bull`, your queues use the default prefix
+3. If you use custom prefixes, bullstudio will auto-discover them. You can also specify them explicitly with `--prefix` or `REDIS_PREFIX`
 
 ### Port already in use
 

--- a/apps/cli/bin/cli.ts
+++ b/apps/cli/bin/cli.ts
@@ -36,9 +36,15 @@ const { values, positionals } = parseArgs({
       short: "h",
       description: "Show help",
     },
+    prefix: {
+      type: "string",
+      description:
+        "Redis key prefix(es), comma-separated (default: auto-discover)",
+    },
     "no-open": {
       type: "boolean",
-      description: "Do not open browser automatically",
+      description:
+        "Do not open browser automatically",
     },
     dev: {
       type: "boolean",
@@ -57,31 +63,37 @@ Usage:
   npx bullstudio [options]
 
 Options:
-  -r, --redis <url>    Redis connection URL (default: redis://localhost:6379)
-  -p, --port <port>    Port to run the server on (default: 4000)
-  --username <user>    Username for HTTP Basic Auth (default: bullstudio)
-  --password <pass>    Password for HTTP Basic Auth
-  --no-open            Do not open browser automatically
-  --dev                Run in development mode (requires source files)
-  -h, --help           Show this help message
+  -r, --redis <url>      Redis connection URL (default: redis://localhost:6379)
+  -p, --port <port>      Port to run the server on (default: 4000)
+  --prefix <prefixes>    Comma-separated key prefixes (default: auto-discover all)
+  --username <user>      Username for HTTP Basic Auth (default: bullstudio)
+  --password <pass>      Password for HTTP Basic Auth
+  --no-open              Do not open browser automatically
+  --dev                  Run in development mode (requires source files)
+  -h, --help             Show this help message
 
 Examples:
   bullstudio
   bullstudio -r redis://localhost:6379
   bullstudio -r redis://:password@myhost.com:6379
   bullstudio -p 5000 -r redis://localhost:6379
+  bullstudio --prefix stage,stage2
   bullstudio --password secret123
   bullstudio --username admin --password secret123
 `);
   process.exit(0);
 }
 
-const redisUrl = values.redis || positionals[0] || "redis://localhost:6379";
+const redisUrl =
+  values.redis ||
+  positionals[0] ||
+  "redis://localhost:6379";
 const port = values.port || "4000";
 const shouldOpen = !values["no-open"];
 const isDev = values.dev;
 const username = values.username;
 const password = values.password;
+const prefixArg = values.prefix;
 
 // Validate Redis URL
 try {
@@ -102,10 +114,11 @@ console.log(`
 │                                             │
 └─────────────────────────────────────────────┘
 
-Redis: ${redisUrl}
-Port:  ${port}
-Mode:  ${isDev ? "development" : "production"}
-Auth:  ${password ? `enabled (username: ${username})` : "disabled"}
+Redis:    ${redisUrl}
+Port:     ${port}
+Prefix:   ${prefixArg || "auto-discover"}
+Mode:     ${isDev ? "development" : "production"}
+Auth:     ${password ? `enabled (username: ${username})` : "disabled"}
 `);
 
 async function openBrowser(url: string) {
@@ -137,16 +150,23 @@ let child: ReturnType<typeof spawn>;
 if (isDev) {
   // Development mode: use vite dev
   console.log("Starting development server...\n");
-  child = spawn("npx", ["vite", "dev", "--port", port], {
-    cwd: appDir,
-    env: {
-      ...process.env,
-      REDIS_URL: redisUrl,
-      PORT: port,
+  child = spawn(
+    "npx",
+    ["vite", "dev", "--port", port],
+    {
+      cwd: appDir,
+      env: {
+        ...process.env,
+        REDIS_URL: redisUrl,
+        PORT: port,
+        ...(prefixArg
+          ? { REDIS_PREFIX: prefixArg }
+          : {}),
+      },
+      stdio: "pipe",
+      shell: true,
     },
-    stdio: "pipe",
-    shell: true,
-  });
+  );
 } else {
   // Production mode: run the built production server
   console.log("Starting production server...\n");
@@ -159,6 +179,9 @@ if (isDev) {
       HOST: "localhost",
       BULLSTUDIO_USERNAME: username,
       BULLSTUDIO_PASSWORD: password,
+      ...(prefixArg
+        ? { REDIS_PREFIX: prefixArg }
+        : {}),
     },
     stdio: "pipe",
   });

--- a/apps/cli/src/components/Sidebar.tsx
+++ b/apps/cli/src/components/Sidebar.tsx
@@ -117,7 +117,9 @@ export function AppSidebar() {
                 <Database className="size-3.5 shrink-0 text-emerald-500" />
                 <div className="flex flex-col group-data-[collapsible=icon]:hidden">
                   <div className="flex items-center gap-2">
-                    <span className="text-zinc-400 font-medium">Redis</span>
+                    <span className="text-zinc-400 font-medium">
+                      Redis
+                    </span>
                     {connectionInfo?.providerType && (
                       <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-zinc-800 text-zinc-400 uppercase">
                         {connectionInfo.providerType}
@@ -125,8 +127,19 @@ export function AppSidebar() {
                     )}
                   </div>
                   <span className="text-zinc-500 font-mono text-[11px]">
-                    {connectionInfo?.displayUrl || "connecting..."}
+                    {connectionInfo?.displayUrl ||
+                      "connecting..."}
                   </span>
+                  {connectionInfo?.prefixes &&
+                    connectionInfo.prefixes
+                      .length > 1 && (
+                      <span className="text-zinc-600 font-mono text-[10px] mt-0.5">
+                        prefixes:{" "}
+                        {connectionInfo.prefixes.join(
+                          ", ",
+                        )}
+                      </span>
+                    )}
                 </div>
               </div>
             </div>

--- a/apps/cli/src/integrations/trpc/connection.ts
+++ b/apps/cli/src/integrations/trpc/connection.ts
@@ -41,30 +41,43 @@ export const getQueueProvider =
 
     if (!connectingPromise) {
       connectingPromise = (async () => {
-        const cfg: QueueServiceConfig = {
-          redisUrl,
-          prefixes: getPrefixes(),
-        };
-        const p = await createQueueProvider(cfg);
-        providerRedisUrl = redisUrl;
-        await p.connect();
-        const caps = p.getCapabilities();
-        console.log(
-          `[CLI] Connected to ` +
-            `${caps.displayName} ` +
-            `(${p.providerType})`,
-        );
-        provider = p;
-        return p;
+        try {
+          const cfg: QueueServiceConfig = {
+            redisUrl,
+            prefixes: getPrefixes(),
+          };
+          const p =
+            await createQueueProvider(cfg);
+          await p.connect();
+          providerRedisUrl = redisUrl;
+          provider = p;
+
+          const caps = p.getCapabilities();
+          console.log(
+            `[CLI] Connected to ` +
+              `${caps.displayName} ` +
+              `(${p.providerType})`,
+          );
+          return p;
+        } catch (error) {
+          provider = null;
+          providerRedisUrl = null;
+          throw error;
+        } finally {
+          connectingPromise = null;
+        }
       })();
     }
 
     return connectingPromise;
   };
 
-export const disconnectProvider = async (): Promise<void> => {
-  if (provider) {
-    await provider.disconnect();
-    provider = null;
-  }
-};
+export const disconnectProvider =
+  async (): Promise<void> => {
+    if (provider) {
+      await provider.disconnect();
+      provider = null;
+      providerRedisUrl = null;
+      connectingPromise = null;
+    }
+  };

--- a/apps/cli/src/integrations/trpc/connection.ts
+++ b/apps/cli/src/integrations/trpc/connection.ts
@@ -1,44 +1,66 @@
-import { createQueueProvider, type QueueService } from "@bullstudio/queue";
+import {
+  createQueueProvider,
+  type QueueService,
+  type QueueServiceConfig,
+} from "@bullstudio/queue";
 
 let provider: QueueService | null = null;
 let providerRedisUrl: string | null = null;
-let connectingPromise: Promise<QueueService> | null = null;
+let connectingPromise: Promise<QueueService> | null =
+  null;
 
 function getRedisUrl(): string {
-  return process.env.REDIS_URL || "redis://localhost:6379";
+  return (
+    process.env.REDIS_URL || "redis://localhost:6379"
+  );
 }
 
-export const getQueueProvider = async (): Promise<QueueService> => {
-  const redisUrl = getRedisUrl();
+function getPrefixes(): string[] | undefined {
+  const raw = process.env.REDIS_PREFIX;
+  if (!raw) return ["*"];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
 
-  // If URL changed, disconnect old provider and create new one
-  if (provider && providerRedisUrl !== redisUrl) {
-    await provider.disconnect();
-    provider = null;
-    providerRedisUrl = null;
-    connectingPromise = null;
-  }
+export const getQueueProvider =
+  async (): Promise<QueueService> => {
+    const redisUrl = getRedisUrl();
 
-  if (provider) {
-    return provider;
-  }
+    if (provider && providerRedisUrl !== redisUrl) {
+      await provider.disconnect();
+      provider = null;
+      providerRedisUrl = null;
+      connectingPromise = null;
+    }
 
-  // Deduplicate concurrent calls by reusing the in-flight promise
-  if (!connectingPromise) {
-    connectingPromise = (async () => {
-      const p = await createQueueProvider({ redisUrl });
-      providerRedisUrl = redisUrl;
-      await p.connect();
-      console.log(
-        `[CLI] Connected to ${p.getCapabilities().displayName} (${p.providerType})`
-      );
-      provider = p;
-      return p;
-    })();
-  }
+    if (provider) {
+      return provider;
+    }
 
-  return connectingPromise;
-};
+    if (!connectingPromise) {
+      connectingPromise = (async () => {
+        const cfg: QueueServiceConfig = {
+          redisUrl,
+          prefixes: getPrefixes(),
+        };
+        const p = await createQueueProvider(cfg);
+        providerRedisUrl = redisUrl;
+        await p.connect();
+        const caps = p.getCapabilities();
+        console.log(
+          `[CLI] Connected to ` +
+            `${caps.displayName} ` +
+            `(${p.providerType})`,
+        );
+        provider = p;
+        return p;
+      })();
+    }
+
+    return connectingPromise;
+  };
 
 export const disconnectProvider = async (): Promise<void> => {
   if (provider) {

--- a/apps/cli/src/integrations/trpc/routers/connection.ts
+++ b/apps/cli/src/integrations/trpc/routers/connection.ts
@@ -31,18 +31,22 @@ export const connectionRouter = createTRPCRouter({
     const provider = await getQueueProvider();
     const capabilities = provider.getCapabilities();
 
+    const prefixes =
+      await provider.getPrefixes();
+
     return {
       host: parsed.host,
       port: parsed.port,
       hasPassword: parsed.hasPassword,
       database: parsed.database,
-      // Don't expose full URL with password
       displayUrl: `${parsed.host}:${parsed.port}`,
-      // Provider info
       providerType: capabilities.providerType,
+      prefixes,
       capabilities: {
-        supportsFlows: capabilities.supportsFlows,
-        supportedStatuses: capabilities.supportedJobStates,
+        supportsFlows:
+          capabilities.supportsFlows,
+        supportedStatuses:
+          capabilities.supportedJobStates,
       },
     };
   }),

--- a/apps/cli/src/integrations/trpc/routers/flow.ts
+++ b/apps/cli/src/integrations/trpc/routers/flow.ts
@@ -110,7 +110,9 @@ export const flowRouter = {
         for (const job of potentialRoots) {
           if (flows.length >= limit) break;
 
-          const jobKey = `${job.queueName}:${job.id}`;
+          const jobKey =
+            `${queue.prefix}:${job.queueName}` +
+            `:${job.id}`;
           if (seenJobIds.has(jobKey)) continue;
           seenJobIds.add(jobKey);
 
@@ -161,7 +163,9 @@ export const flowRouter = {
         for (const job of waitingChildrenJobs) {
           if (flows.length >= limit) break;
 
-          const jobKey = `${job.queueName}:${job.id}`;
+          const jobKey =
+            `${queue.prefix}:${job.queueName}` +
+            `:${job.id}`;
           if (seenJobIds.has(jobKey)) continue;
           seenJobIds.add(jobKey);
 

--- a/apps/cli/src/integrations/trpc/routers/flow.ts
+++ b/apps/cli/src/integrations/trpc/routers/flow.ts
@@ -118,6 +118,7 @@ export const flowRouter = {
             const flowTree = await fp.getFlow({
               id: job.id,
               queueName: job.queueName,
+              prefix: queue.prefix,
             });
 
             if (flowTree?.children && flowTree.children.length > 0) {
@@ -141,7 +142,6 @@ export const flowRouter = {
         }
       }
 
-      // Also check jobs with waiting-children status
       for (const queue of queues) {
         if (flows.length >= limit) break;
 
@@ -164,12 +164,13 @@ export const flowRouter = {
           if (seenJobIds.has(jobKey)) continue;
           seenJobIds.add(jobKey);
 
-          if (job.parentId) continue; // Skip children
+          if (job.parentId) continue;
 
           try {
             const flowTree = await fp.getFlow({
               id: job.id,
               queueName: job.queueName,
+              prefix: queue.prefix,
             });
 
             if (flowTree?.children && flowTree.children.length > 0) {

--- a/apps/cli/src/integrations/trpc/routers/flow.ts
+++ b/apps/cli/src/integrations/trpc/routers/flow.ts
@@ -129,6 +129,7 @@ export const flowRouter = {
                 id: job.id,
                 name: job.name,
                 queueName: job.queueName,
+                prefix: queue.prefix,
                 status: state as JobStatus,
                 totalJobs: stats.total,
                 completedJobs: stats.completed,
@@ -180,6 +181,7 @@ export const flowRouter = {
                 id: job.id,
                 name: job.name,
                 queueName: job.queueName,
+                prefix: queue.prefix,
                 status: job.status,
                 totalJobs: stats.total,
                 completedJobs: stats.completed,
@@ -197,52 +199,73 @@ export const flowRouter = {
     }),
 
   get: publicProcedure
-    .input(z.object({ queueName: z.string(), flowId: z.string() }))
-    .query(async ({ input }): Promise<FlowTree> => {
-      const provider = await getQueueProvider();
+    .input(
+      z.object({
+        queueName: z.string(),
+        flowId: z.string(),
+        prefix: z.string().optional(),
+      }),
+    )
+    .query(
+      async ({ input }): Promise<FlowTree> => {
+        const provider =
+          await getQueueProvider();
 
-      // Check if flows are supported
-      const capabilities = provider.getCapabilities();
-      if (!capabilities.supportsFlows) {
-        throw new TRPCError({
-          code: "BAD_REQUEST",
-          message: "Flows are not supported by this queue provider (Bull)",
-        });
-      }
-
-      const fp = await getFlowProducer();
-
-      try {
-        const flowTree = await fp.getFlow({
-          id: input.flowId,
-          queueName: input.queueName,
-        });
-
-        if (!flowTree) {
+        const capabilities =
+          provider.getCapabilities();
+        if (!capabilities.supportsFlows) {
           throw new TRPCError({
-            code: "NOT_FOUND",
-            message: `Flow ${input.flowId} not found in queue ${input.queueName}`,
+            code: "BAD_REQUEST",
+            message:
+              "Flows are not supported by " +
+              "this queue provider (Bull)",
           });
         }
 
-        const root = await convertFlowTree(flowTree);
-        const stats = await countFlowStats(flowTree);
+        const fp = await getFlowProducer();
 
-        return {
-          id: input.flowId,
-          root,
-          queueName: input.queueName,
-          totalNodes: stats.total,
-          completedNodes: stats.completed,
-          failedNodes: stats.failed,
-        };
-      } catch (error) {
-        if (error instanceof TRPCError) throw error;
+        try {
+          const flowTree = await fp.getFlow({
+            id: input.flowId,
+            queueName: input.queueName,
+            prefix: input.prefix,
+          });
 
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: `Flow ${input.flowId} not found in queue ${input.queueName}`,
-        });
-      }
-    }),
+          if (!flowTree) {
+            throw new TRPCError({
+              code: "NOT_FOUND",
+              message:
+                `Flow ${input.flowId} not ` +
+                `found in queue ` +
+                `${input.queueName}`,
+            });
+          }
+
+          const root =
+            await convertFlowTree(flowTree);
+          const stats =
+            await countFlowStats(flowTree);
+
+          return {
+            id: input.flowId,
+            root,
+            queueName: input.queueName,
+            totalNodes: stats.total,
+            completedNodes: stats.completed,
+            failedNodes: stats.failed,
+          };
+        } catch (error) {
+          if (error instanceof TRPCError) {
+            throw error;
+          }
+          throw new TRPCError({
+            code: "NOT_FOUND",
+            message:
+              `Flow ${input.flowId} not ` +
+              `found in queue ` +
+              `${input.queueName}`,
+          });
+        }
+      },
+    ),
 } satisfies TRPCRouterRecord;

--- a/apps/cli/src/integrations/trpc/routers/flow.ts
+++ b/apps/cli/src/integrations/trpc/routers/flow.ts
@@ -99,7 +99,11 @@ export const flowRouter = {
       for (const queue of queues) {
         if (flows.length >= limit) break;
 
-        const jobs = await provider.getJobsSummary(queue.name, { limit: 500 });
+        const jobs = await provider.getJobsSummary(
+          queue.name,
+          { limit: 500 },
+          queue.prefix,
+        );
 
         const potentialRoots = jobs.filter((job) => !job.parentId);
 
@@ -141,10 +145,17 @@ export const flowRouter = {
       for (const queue of queues) {
         if (flows.length >= limit) break;
 
-        const waitingChildrenJobs = await provider.getJobs(queue.name, {
-          filter: { status: "waiting-children" },
-          limit: 100,
-        });
+        const waitingChildrenJobs =
+          await provider.getJobs(
+            queue.name,
+            {
+              filter: {
+                status: "waiting-children",
+              },
+              limit: 100,
+            },
+            queue.prefix,
+          );
 
         for (const job of waitingChildrenJobs) {
           if (flows.length >= limit) break;

--- a/apps/cli/src/integrations/trpc/routers/job.ts
+++ b/apps/cli/src/integrations/trpc/routers/job.ts
@@ -41,14 +41,21 @@ export const jobRouter = {
       const provider = await getQueueProvider();
       const queues = await provider.getQueues();
 
-      const queuesToFetch = input?.queueName
-        ? queues.filter(
-            (q) =>
-              q.name === input.queueName &&
-              (!input.prefix ||
-                q.prefix === input.prefix),
+      const queuesToFetch = queues.filter(
+        (q) => {
+          if (
+            input?.queueName &&
+            q.name !== input.queueName
           )
-        : queues;
+            return false;
+          if (
+            input?.prefix &&
+            q.prefix !== input.prefix
+          )
+            return false;
+          return true;
+        },
+      );
 
       const allJobs: Job[] = [];
       for (const queue of queuesToFetch) {
@@ -95,14 +102,21 @@ export const jobRouter = {
         const provider = await getQueueProvider();
         const queues = await provider.getQueues();
 
-        const queuesToFetch = input?.queueName
-          ? queues.filter(
-              (q) =>
-                q.name === input.queueName &&
-                (!input.prefix ||
-                  q.prefix === input.prefix),
+        const queuesToFetch = queues.filter(
+          (q) => {
+            if (
+              input?.queueName &&
+              q.name !== input.queueName
             )
-          : queues;
+              return false;
+            if (
+              input?.prefix &&
+              q.prefix !== input.prefix
+            )
+              return false;
+            return true;
+          },
+        );
 
         const allJobs: JobSummary[] = [];
         for (const queue of queuesToFetch) {

--- a/apps/cli/src/integrations/trpc/routers/job.ts
+++ b/apps/cli/src/integrations/trpc/routers/job.ts
@@ -15,14 +15,24 @@ const jobStatusSchema = z.enum([
   "waiting-children",
 ]);
 
+const queueIdSchema = z.object({
+  queueName: z.string(),
+  prefix: z.string().optional(),
+});
+
 export const jobRouter = {
   list: publicProcedure
     .input(
       z
         .object({
           queueName: z.string().optional(),
+          prefix: z.string().optional(),
           status: jobStatusSchema.optional(),
-          limit: z.number().min(1).max(1000).default(100),
+          limit: z
+            .number()
+            .min(1)
+            .max(1000)
+            .default(100),
           offset: z.number().min(0).default(0),
         })
         .optional(),
@@ -32,21 +42,36 @@ export const jobRouter = {
       const queues = await provider.getQueues();
 
       const queuesToFetch = input?.queueName
-        ? queues.filter((q) => q.name === input.queueName)
+        ? queues.filter(
+            (q) =>
+              q.name === input.queueName &&
+              (!input.prefix ||
+                q.prefix === input.prefix),
+          )
         : queues;
 
       const allJobs: Job[] = [];
       for (const queue of queuesToFetch) {
-        const jobs = await provider.getJobs(queue.name, {
-          filter: input?.status ? { status: input.status } : undefined,
-          limit: input?.limit ?? 100,
-          offset: input?.offset ?? 0,
-        });
+        const jobs = await provider.getJobs(
+          queue.name,
+          {
+            filter: input?.status
+              ? { status: input.status }
+              : undefined,
+            limit: input?.limit ?? 100,
+            offset: input?.offset ?? 0,
+          },
+          queue.prefix,
+        );
+        for (const j of jobs) {
+          j.prefix = queue.prefix;
+        }
         allJobs.push(...jobs);
       }
 
-      // Sort by timestamp descending
-      return allJobs.sort((a, b) => b.timestamp - a.timestamp);
+      return allJobs.sort(
+        (a, b) => b.timestamp - a.timestamp,
+      );
     }),
 
   listSummary: publicProcedure
@@ -54,107 +79,185 @@ export const jobRouter = {
       z
         .object({
           queueName: z.string().optional(),
+          prefix: z.string().optional(),
           status: jobStatusSchema.optional(),
-          limit: z.number().min(1).max(1000).default(100),
+          limit: z
+            .number()
+            .min(1)
+            .max(1000)
+            .default(100),
           offset: z.number().min(0).default(0),
         })
         .optional(),
     )
-    .query(async ({ input }): Promise<JobSummary[]> => {
-      const provider = await getQueueProvider();
-      const queues = await provider.getQueues();
+    .query(
+      async ({ input }): Promise<JobSummary[]> => {
+        const provider = await getQueueProvider();
+        const queues = await provider.getQueues();
 
-      const queuesToFetch = input?.queueName
-        ? queues.filter((q) => q.name === input.queueName)
-        : queues;
+        const queuesToFetch = input?.queueName
+          ? queues.filter(
+              (q) =>
+                q.name === input.queueName &&
+                (!input.prefix ||
+                  q.prefix === input.prefix),
+            )
+          : queues;
 
-      const allJobs: JobSummary[] = [];
-      for (const queue of queuesToFetch) {
-        const jobs = await provider.getJobsSummary(queue.name, {
-          filter: input?.status ? { status: input.status } : undefined,
-          limit: input?.limit ?? 100,
-          offset: input?.offset ?? 0,
-        });
-        allJobs.push(...jobs);
-      }
+        const allJobs: JobSummary[] = [];
+        for (const queue of queuesToFetch) {
+          const jobs =
+            await provider.getJobsSummary(
+              queue.name,
+              {
+                filter: input?.status
+                  ? { status: input.status }
+                  : undefined,
+                limit: input?.limit ?? 100,
+                offset: input?.offset ?? 0,
+              },
+              queue.prefix,
+            );
+          for (const j of jobs) {
+            j.prefix = queue.prefix;
+          }
+          allJobs.push(...jobs);
+        }
 
-      // Sort by timestamp descending
-      return allJobs.sort((a, b) => b.timestamp - a.timestamp);
-    }),
+        return allJobs.sort(
+          (a, b) => b.timestamp - a.timestamp,
+        );
+      },
+    ),
 
   get: publicProcedure
-    .input(z.object({ queueName: z.string(), jobId: z.string() }))
-    .query(async ({ input }): Promise<Job | null> => {
-      const provider = await getQueueProvider();
-      return provider.getJob(input.queueName, input.jobId);
-    }),
+    .input(
+      queueIdSchema.extend({
+        jobId: z.string(),
+      }),
+    )
+    .query(
+      async ({ input }): Promise<Job | null> => {
+        const provider = await getQueueProvider();
+        return provider.getJob(
+          input.queueName,
+          input.jobId,
+          input.prefix,
+        );
+      },
+    ),
 
   logs: publicProcedure
-    .input(z.object({ queueName: z.string(), jobId: z.string() }))
+    .input(
+      queueIdSchema.extend({
+        jobId: z.string(),
+      }),
+    )
     .query(async ({ input }) => {
       const provider = await getQueueProvider();
-      return provider.getJobLogs(input.queueName, input.jobId);
+      return provider.getJobLogs(
+        input.queueName,
+        input.jobId,
+        input.prefix,
+      );
     }),
 
   retry: publicProcedure
-    .input(z.object({ queueName: z.string(), jobId: z.string() }))
+    .input(
+      queueIdSchema.extend({
+        jobId: z.string(),
+      }),
+    )
     .mutation(async ({ input }) => {
       const provider = await getQueueProvider();
 
-      // First check if the job exists and is in a failed state
-      const job = await provider.getJob(input.queueName, input.jobId);
+      const job = await provider.getJob(
+        input.queueName,
+        input.jobId,
+        input.prefix,
+      );
       if (!job) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: `Job ${input.jobId} not found in queue ${input.queueName}`,
+          message:
+            `Job ${input.jobId} not found ` +
+            `in queue ${input.queueName}`,
         });
       }
 
       if (job.status !== "failed") {
         throw new TRPCError({
           code: "BAD_REQUEST",
-          message: `Job is not in failed state. Current status: ${job.status}`,
+          message:
+            `Job is not in failed state. ` +
+            `Current status: ${job.status}`,
         });
       }
 
-      // Check if there are workers available to process the job
-      const workerCount = await provider.getWorkerCount(input.queueName);
+      const workerCount =
+        await provider.getWorkerCount(
+          input.queueName,
+          input.prefix,
+        );
       if (workerCount.count === 0) {
         throw new TRPCError({
           code: "PRECONDITION_FAILED",
-          message: `No workers available for queue "${input.queueName}". Start a worker to process retried jobs.`,
+          message:
+            `No workers available for ` +
+            `queue "${input.queueName}". ` +
+            `Start a worker to process ` +
+            `retried jobs.`,
         });
       }
 
-      // Retry the job
-      await provider.retryJob(input.queueName, input.jobId);
+      await provider.retryJob(
+        input.queueName,
+        input.jobId,
+        input.prefix,
+      );
 
       return {
         success: true,
-        message: `Job "${job.name}" has been enqueued for retry`,
+        message:
+          `Job "${job.name}" has been ` +
+          `enqueued for retry`,
         workerCount: workerCount.count,
       };
     }),
 
   remove: publicProcedure
-    .input(z.object({ queueName: z.string(), jobId: z.string() }))
+    .input(
+      queueIdSchema.extend({
+        jobId: z.string(),
+      }),
+    )
     .mutation(async ({ input }) => {
       const provider = await getQueueProvider();
 
-      // Check if job exists
-      const job = await provider.getJob(input.queueName, input.jobId);
+      const job = await provider.getJob(
+        input.queueName,
+        input.jobId,
+        input.prefix,
+      );
       if (!job) {
         throw new TRPCError({
           code: "NOT_FOUND",
-          message: `Job ${input.jobId} not found in queue ${input.queueName}`,
+          message:
+            `Job ${input.jobId} not found ` +
+            `in queue ${input.queueName}`,
         });
       }
 
-      await provider.removeJob(input.queueName, input.jobId);
+      await provider.removeJob(
+        input.queueName,
+        input.jobId,
+        input.prefix,
+      );
 
       return {
         success: true,
-        message: `Job "${job.name}" has been removed`,
+        message:
+          `Job "${job.name}" has been removed`,
       };
     }),
 } satisfies TRPCRouterRecord;

--- a/apps/cli/src/integrations/trpc/routers/overview.ts
+++ b/apps/cli/src/integrations/trpc/routers/overview.ts
@@ -204,32 +204,57 @@ export const overviewRouter = {
     .input(
       z.object({
         queueName: z.string().optional(),
-        timeRangeHours: z.number().min(1).max(168).default(24),
+        prefix: z.string().optional(),
+        timeRangeHours: z
+          .number()
+          .min(1)
+          .max(168)
+          .default(24),
       }),
     )
-    .query(async ({ input }): Promise<OverviewMetricsResponse> => {
-      const provider = await getQueueProvider();
-      const allQueues = await provider.getQueues();
-      const timeRangeMs = input.timeRangeHours * 60 * 60 * 1000;
-      const cutoffTimestamp = Date.now() - timeRangeMs;
+    .query(
+      async ({
+        input,
+      }): Promise<OverviewMetricsResponse> => {
+        const provider = await getQueueProvider();
+        const allQueues =
+          await provider.getQueues();
+        const timeRangeMs =
+          input.timeRangeHours * 60 * 60 * 1000;
+        const cutoffTimestamp =
+          Date.now() - timeRangeMs;
 
-      const queuesToProcess = input.queueName
-        ? allQueues.filter((q) => q.name === input.queueName)
-        : allQueues;
+        const queuesToProcess = input.queueName
+          ? allQueues.filter(
+              (q) =>
+                q.name === input.queueName &&
+                (!input.prefix ||
+                  q.prefix === input.prefix),
+            )
+          : allQueues;
 
       const allJobs: JobSummary[] = [];
 
       for (const queue of queuesToProcess) {
-        const [completed, failed] = await Promise.all([
-          provider.getJobsSummary(queue.name, {
-            filter: { status: "completed" },
-            limit: 1000,
-          }),
-          provider.getJobsSummary(queue.name, {
-            filter: { status: "failed" },
-            limit: 1000,
-          }),
-        ]);
+        const [completed, failed] =
+          await Promise.all([
+            provider.getJobsSummary(
+              queue.name,
+              {
+                filter: { status: "completed" },
+                limit: 1000,
+              },
+              queue.prefix,
+            ),
+            provider.getJobsSummary(
+              queue.name,
+              {
+                filter: { status: "failed" },
+                limit: 1000,
+              },
+              queue.prefix,
+            ),
+          ]);
 
         allJobs.push(
           ...completed.filter(

--- a/apps/cli/src/integrations/trpc/routers/queue.ts
+++ b/apps/cli/src/integrations/trpc/routers/queue.ts
@@ -5,31 +5,67 @@ import { getQueueProvider } from "../connection";
 import type { Queue } from "@bullstudio/connect-types";
 
 export const queueRouter = {
-  list: publicProcedure.query(async (): Promise<Queue[]> => {
-    const provider = await getQueueProvider();
-    return provider.getQueues();
-  }),
+  list: publicProcedure.query(
+    async (): Promise<Queue[]> => {
+      const provider = await getQueueProvider();
+      return provider.getQueues();
+    },
+  ),
+
+  prefixes: publicProcedure.query(
+    async (): Promise<string[]> => {
+      const provider = await getQueueProvider();
+      return provider.getPrefixes();
+    },
+  ),
 
   get: publicProcedure
-    .input(z.object({ name: z.string() }))
-    .query(async ({ input }): Promise<Queue | null> => {
-      const provider = await getQueueProvider();
-      return provider.getQueue(input.name);
-    }),
+    .input(
+      z.object({
+        name: z.string(),
+        prefix: z.string().optional(),
+      }),
+    )
+    .query(
+      async ({ input }): Promise<Queue | null> => {
+        const provider =
+          await getQueueProvider();
+        return provider.getQueue(
+          input.name,
+          input.prefix,
+        );
+      },
+    ),
 
   pause: publicProcedure
-    .input(z.object({ name: z.string() }))
+    .input(
+      z.object({
+        name: z.string(),
+        prefix: z.string().optional(),
+      }),
+    )
     .mutation(async ({ input }) => {
       const provider = await getQueueProvider();
-      await provider.pauseQueue(input.name);
+      await provider.pauseQueue(
+        input.name,
+        input.prefix,
+      );
       return { success: true };
     }),
 
   resume: publicProcedure
-    .input(z.object({ name: z.string() }))
+    .input(
+      z.object({
+        name: z.string(),
+        prefix: z.string().optional(),
+      }),
+    )
     .mutation(async ({ input }) => {
       const provider = await getQueueProvider();
-      await provider.resumeQueue(input.name);
+      await provider.resumeQueue(
+        input.name,
+        input.prefix,
+      );
       return { success: true };
     }),
 } satisfies TRPCRouterRecord;

--- a/apps/cli/src/lib/queue-key.ts
+++ b/apps/cli/src/lib/queue-key.ts
@@ -1,0 +1,21 @@
+const COMPOSITE_SEP = "::";
+
+export function queueKey(
+  prefix: string,
+  name: string,
+): string {
+  return `${prefix}${COMPOSITE_SEP}${name}`;
+}
+
+export function parseQueueKey(
+  key: string,
+): { prefix: string; name: string } | null {
+  const idx = key.indexOf(COMPOSITE_SEP);
+  if (idx === -1) return null;
+  return {
+    prefix: key.slice(0, idx),
+    name: key.slice(
+      idx + COMPOSITE_SEP.length,
+    ),
+  };
+}

--- a/apps/cli/src/routes/flows/$flowId.tsx
+++ b/apps/cli/src/routes/flows/$flowId.tsx
@@ -23,6 +23,7 @@ import type { FlowNode } from "@bullstudio/connect-types";
 
 const searchSchema = z.object({
   queueName: z.string(),
+  prefix: z.string().optional(),
 });
 
 export const Route = createFileRoute("/flows/$flowId")({
@@ -39,7 +40,7 @@ function checkHasActiveJobs(node: FlowNode): boolean {
 
 function FlowDetailPage() {
   const { flowId } = Route.useParams();
-  const { queueName } = Route.useSearch();
+  const { queueName, prefix } = Route.useSearch();
   const navigate = useNavigate();
   const trpc = useTRPC();
 
@@ -50,7 +51,7 @@ function FlowDetailPage() {
     isFetching,
   } = useQuery(
     trpc.flows.get.queryOptions(
-      { queueName, flowId },
+      { queueName, flowId, prefix },
       {
         refetchInterval(query) {
           const data = query.state.data;

--- a/apps/cli/src/routes/flows/$flowId.tsx
+++ b/apps/cli/src/routes/flows/$flowId.tsx
@@ -71,10 +71,13 @@ function FlowDetailPage() {
       navigate({
         to: "/jobs/$jobId",
         params: { jobId },
-        search: { queueName: jobQueueName },
+        search: {
+          queueName: jobQueueName,
+          prefix,
+        },
       });
     },
-    [navigate]
+    [navigate, prefix]
   );
 
   if (isLoading) {

--- a/apps/cli/src/routes/flows/index.tsx
+++ b/apps/cli/src/routes/flows/index.tsx
@@ -48,11 +48,18 @@ function FlowsPage() {
     })
   );
 
-  const navigateToFlow = (flowId: string, queueName: string) => {
+  const navigateToFlow = (
+    flowId: string,
+    queueName: string,
+    flowPrefix?: string,
+  ) => {
     navigate({
       to: "/flows/$flowId",
       params: { flowId },
-      search: { queueName },
+      search: {
+        queueName,
+        prefix: flowPrefix,
+      },
     });
   };
 
@@ -105,7 +112,11 @@ function FlowsPage() {
                 <TableRow
                   key={`${flow.queueName}-${flow.id}`}
                   className="border-zinc-800 cursor-pointer hover:bg-zinc-800/50 transition-colors"
-                  onClick={() => navigateToFlow(flow.id, flow.queueName)}
+                  onClick={() => navigateToFlow(
+  flow.id,
+  flow.queueName,
+  flow.prefix,
+)}
                 >
                   <TableCell>
                     <div className="flex items-center gap-3">

--- a/apps/cli/src/routes/flows/index.tsx
+++ b/apps/cli/src/routes/flows/index.tsx
@@ -1,10 +1,10 @@
-"use client";
+"use client"
 
-import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useTRPC } from "@/integrations/trpc/react";
-import { useQuery } from "@tanstack/react-query";
-import Header from "@/components/Header";
-import { Button } from "@bullstudio/ui/components/button";
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { useTRPC } from "@/integrations/trpc/react"
+import { useQuery } from "@tanstack/react-query"
+import Header from "@/components/Header"
+import { Button } from "@bullstudio/ui/components/button"
 import {
   Table,
   TableBody,
@@ -12,23 +12,23 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from "@bullstudio/ui/components/table";
-import { Skeleton } from "@bullstudio/ui/components/skeleton";
+} from "@bullstudio/ui/components/table"
+import { Skeleton } from "@bullstudio/ui/components/skeleton"
 import {
   JobStatusBadge,
   type JobStatus,
   EmptyState,
-} from "@bullstudio/ui/shared";
-import { Workflow, RefreshCw, Inbox, CheckCircle, XCircle } from "lucide-react";
-import dayjs from "@bullstudio/dayjs";
+} from "@bullstudio/ui/shared"
+import { Workflow, RefreshCw, Inbox, CheckCircle, XCircle } from "lucide-react"
+import dayjs from "@bullstudio/dayjs"
 
 export const Route = createFileRoute("/flows/")({
   component: FlowsPage,
-});
+})
 
 function FlowsPage() {
-  const trpc = useTRPC();
-  const navigate = useNavigate();
+  const trpc = useTRPC()
+  const navigate = useNavigate()
 
   const {
     data: flows,
@@ -38,15 +38,15 @@ function FlowsPage() {
   } = useQuery(
     trpc.flows.list.queryOptions(undefined, {
       refetchInterval(query) {
-        const flowsData = query.state.data;
-        if (!flowsData || flowsData.length === 0) return false;
+        const flowsData = query.state.data
+        if (!flowsData || flowsData.length === 0) return false
         const hasActiveFlows = flowsData.some(
-          (f) => !["completed", "failed"].includes(f.status)
-        );
-        return hasActiveFlows ? 2000 : false;
+          (f) => !["completed", "failed"].includes(f.status),
+        )
+        return hasActiveFlows ? 2000 : false
       },
-    })
-  );
+    }),
+  )
 
   const navigateToFlow = (
     flowId: string,
@@ -60,8 +60,8 @@ function FlowsPage() {
         queueName,
         prefix: flowPrefix,
       },
-    });
-  };
+    })
+  }
 
   return (
     <div className="space-y-6">
@@ -110,13 +110,11 @@ function FlowsPage() {
             <TableBody>
               {flows.map((flow) => (
                 <TableRow
-                  key={`${flow.queueName}-${flow.id}`}
+                  key={`${flow.prefix}-${flow.queueName}-${flow.id}`}
                   className="border-zinc-800 cursor-pointer hover:bg-zinc-800/50 transition-colors"
-                  onClick={() => navigateToFlow(
-  flow.id,
-  flow.queueName,
-  flow.prefix,
-)}
+                  onClick={() =>
+                    navigateToFlow(flow.id, flow.queueName, flow.prefix)
+                  }
                 >
                   <TableCell>
                     <div className="flex items-center gap-3">
@@ -139,7 +137,10 @@ function FlowsPage() {
                     </span>
                   </TableCell>
                   <TableCell>
-                    <JobStatusBadge status={flow.status as JobStatus} size="sm" />
+                    <JobStatusBadge
+                      status={flow.status as JobStatus}
+                      size="sm"
+                    />
                   </TableCell>
                   <TableCell>
                     <div className="flex flex-col gap-1">
@@ -183,5 +184,5 @@ function FlowsPage() {
         </div>
       )}
     </div>
-  );
+  )
 }

--- a/apps/cli/src/routes/index.tsx
+++ b/apps/cli/src/routes/index.tsx
@@ -32,15 +32,46 @@ const TIME_RANGES = [
 ];
 
 const ALL_QUEUES_VALUE = "__all__";
+const COMPOSITE_SEP = "::";
+
+function queueKey(
+  prefix: string,
+  name: string,
+): string {
+  return `${prefix}${COMPOSITE_SEP}${name}`;
+}
+
+function parseQueueKey(
+  key: string,
+): { prefix: string; name: string } | null {
+  const idx = key.indexOf(COMPOSITE_SEP);
+  if (idx === -1) return null;
+  return {
+    prefix: key.slice(0, idx),
+    name: key.slice(idx + COMPOSITE_SEP.length),
+  };
+}
 
 function OverviewPage() {
   const trpc = useTRPC();
-  const [queueName, setQueueName] = useState<string>("");
-  const [timeRange, setTimeRange] = useState<number>(24);
+  const [selectedQueue, setSelectedQueue] =
+    useState<string>("");
+  const [timeRange, setTimeRange] =
+    useState<number>(24);
 
-  const { data: queues, isLoading: loadingQueues } = useQuery(
-    trpc.queues.list.queryOptions(),
+  const { data: queues, isLoading: loadingQueues } =
+    useQuery(trpc.queues.list.queryOptions());
+
+  const { data: connectionInfo } = useQuery(
+    trpc.connection.info.queryOptions(),
   );
+
+  const hasMultiplePrefixes =
+    (connectionInfo?.prefixes?.length ?? 0) > 1;
+
+  const parsed = selectedQueue
+    ? parseQueueKey(selectedQueue)
+    : null;
 
   const {
     data: metrics,
@@ -50,7 +81,8 @@ function OverviewPage() {
   } = useQuery(
     trpc.overview.metrics.queryOptions({
       timeRangeHours: timeRange,
-      queueName: queueName || undefined,
+      queueName: parsed?.name,
+      prefix: parsed?.prefix,
     }),
   );
 
@@ -62,26 +94,46 @@ function OverviewPage() {
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-wrap items-center gap-3">
           <Select
-            value={queueName || ALL_QUEUES_VALUE}
+            value={
+              selectedQueue || ALL_QUEUES_VALUE
+            }
             onValueChange={(value) =>
-              setQueueName(value === ALL_QUEUES_VALUE ? "" : value)
+              setSelectedQueue(
+                value === ALL_QUEUES_VALUE
+                  ? ""
+                  : value,
+              )
             }
             disabled={loadingQueues}
           >
-            <SelectTrigger className="w-[200px] bg-zinc-900/50 border-zinc-800">
+            <SelectTrigger className="w-[250px] bg-zinc-900/50 border-zinc-800">
               <Layers className="size-4 mr-2 text-zinc-500" />
               <SelectValue placeholder="Select queue" />
             </SelectTrigger>
             <SelectContent className="bg-zinc-900 border-zinc-800">
-              <SelectItem value={ALL_QUEUES_VALUE} className="text-zinc-100">
+              <SelectItem
+                value={ALL_QUEUES_VALUE}
+                className="text-zinc-100"
+              >
                 All queues
               </SelectItem>
               {queues?.map((queue) => (
                 <SelectItem
-                  key={queue.name}
-                  value={queue.name}
+                  key={queueKey(
+                    queue.prefix,
+                    queue.name,
+                  )}
+                  value={queueKey(
+                    queue.prefix,
+                    queue.name,
+                  )}
                   className="text-zinc-100 font-mono"
                 >
+                  {hasMultiplePrefixes && (
+                    <span className="text-zinc-500 mr-1">
+                      {queue.prefix}/
+                    </span>
+                  )}
                   {queue.name}
                 </SelectItem>
               ))}

--- a/apps/cli/src/routes/index.tsx
+++ b/apps/cli/src/routes/index.tsx
@@ -31,26 +31,9 @@ const TIME_RANGES = [
   { value: "168", label: "Last 7d" },
 ];
 
+import { queueKey, parseQueueKey } from "@/lib/queue-key";
+
 const ALL_QUEUES_VALUE = "__all__";
-const COMPOSITE_SEP = "::";
-
-function queueKey(
-  prefix: string,
-  name: string,
-): string {
-  return `${prefix}${COMPOSITE_SEP}${name}`;
-}
-
-function parseQueueKey(
-  key: string,
-): { prefix: string; name: string } | null {
-  const idx = key.indexOf(COMPOSITE_SEP);
-  if (idx === -1) return null;
-  return {
-    prefix: key.slice(0, idx),
-    name: key.slice(idx + COMPOSITE_SEP.length),
-  };
-}
 
 function OverviewPage() {
   const trpc = useTRPC();

--- a/apps/cli/src/routes/jobs/$jobId.tsx
+++ b/apps/cli/src/routes/jobs/$jobId.tsx
@@ -40,6 +40,7 @@ import { z } from "zod";
 
 const searchSchema = z.object({
   queueName: z.string(),
+  prefix: z.string().optional(),
 });
 
 export const Route = createFileRoute("/jobs/$jobId")({
@@ -49,7 +50,7 @@ export const Route = createFileRoute("/jobs/$jobId")({
 
 function JobDetailPage() {
   const { jobId } = Route.useParams();
-  const { queueName } = Route.useSearch();
+  const { queueName, prefix } = Route.useSearch();
   const navigate = useNavigate();
   const trpc = useTRPC();
   const queryClient = useQueryClient();
@@ -64,6 +65,7 @@ function JobDetailPage() {
       {
         queueName,
         jobId,
+        prefix,
       },
       {
         refetchInterval(query) {
@@ -77,7 +79,10 @@ function JobDetailPage() {
   );
 
   const { data: logsData } = useQuery(
-    trpc.jobs.logs.queryOptions({ queueName, jobId }, { enabled: !!job }),
+    trpc.jobs.logs.queryOptions(
+      { queueName, jobId, prefix },
+      { enabled: !!job },
+    ),
   );
 
   const retryMutation = useMutation(
@@ -158,11 +163,19 @@ function JobDetailPage() {
   };
 
   const handleRetry = () => {
-    retryMutation.mutate({ queueName, jobId });
+    retryMutation.mutate({
+      queueName,
+      jobId,
+      prefix,
+    });
   };
 
   const handleRemove = () => {
-    removeMutation.mutate({ queueName, jobId });
+    removeMutation.mutate({
+      queueName,
+      jobId,
+      prefix,
+    });
   };
 
   return (

--- a/apps/cli/src/routes/jobs/index.tsx
+++ b/apps/cli/src/routes/jobs/index.tsx
@@ -60,6 +60,25 @@ const BASE_STATUS_TABS: { value: FilterableStatus | "all"; label: string }[] = [
 
 const ALL_QUEUES_VALUE = "__all__";
 const SEARCH_DEBOUNCE_MS = 300;
+const COMPOSITE_SEP = "::";
+
+function queueKey(
+  prefix: string,
+  name: string,
+): string {
+  return `${prefix}${COMPOSITE_SEP}${name}`;
+}
+
+function parseQueueKey(
+  key: string,
+): { prefix: string; name: string } | null {
+  const idx = key.indexOf(COMPOSITE_SEP);
+  if (idx === -1) return null;
+  return {
+    prefix: key.slice(0, idx),
+    name: key.slice(idx + COMPOSITE_SEP.length),
+  };
+}
 
 function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);
@@ -76,19 +95,31 @@ function JobsPage() {
   const trpc = useTRPC();
   const navigate = useNavigate();
 
-  const [queueName, setQueueName] = useState<string>("");
-  const [statusFilter, setStatusFilter] = useState<FilterableStatus | "all">(
-    "all"
+  const [selectedQueue, setSelectedQueue] =
+    useState<string>("");
+  const [statusFilter, setStatusFilter] =
+    useState<FilterableStatus | "all">("all");
+  const [searchQuery, setSearchQuery] =
+    useState("");
+  const debouncedSearchQuery = useDebounce(
+    searchQuery,
+    SEARCH_DEBOUNCE_MS,
   );
-  const [searchQuery, setSearchQuery] = useState("");
-  const debouncedSearchQuery = useDebounce(searchQuery, SEARCH_DEBOUNCE_MS);
-  const [sortField, setSortField] = useState<SortField>("timestamp");
-  const [sortOrder, setSortOrder] = useState<SortOrder>("desc");
+  const [sortField, setSortField] =
+    useState<SortField>("timestamp");
+  const [sortOrder, setSortOrder] =
+    useState<SortOrder>("desc");
 
-  // Fetch connection info for capabilities
   const { data: connectionInfo } = useQuery(
-    trpc.connection.info.queryOptions()
+    trpc.connection.info.queryOptions(),
   );
+
+  const hasMultiplePrefixes =
+    (connectionInfo?.prefixes?.length ?? 0) > 1;
+
+  const parsed = selectedQueue
+    ? parseQueueKey(selectedQueue)
+    : null;
 
   // Build status tabs based on provider capabilities
   const statusTabs = useMemo(() => {
@@ -102,22 +133,25 @@ function JobsPage() {
     return BASE_STATUS_TABS;
   }, [connectionInfo?.capabilities?.supportsFlows]);
 
-  // Fetch queues
-  const { data: queues, isLoading: loadingQueues } = useQuery(
-    trpc.queues.list.queryOptions()
-  );
+  const {
+    data: queues,
+    isLoading: loadingQueues,
+  } = useQuery(trpc.queues.list.queryOptions());
 
-  // Fetch jobs (using summary endpoint for better performance)
   const {
     data: jobs,
     isLoading: loadingJobs,
     refetch: refetchJobs,
   } = useQuery(
     trpc.jobs.listSummary.queryOptions({
-      queueName: queueName || undefined,
-      status: statusFilter !== "all" ? statusFilter : undefined,
+      queueName: parsed?.name,
+      prefix: parsed?.prefix,
+      status:
+        statusFilter !== "all"
+          ? statusFilter
+          : undefined,
       limit: 500,
-    })
+    }),
   );
 
   // Client-side filtering and sorting
@@ -223,11 +257,18 @@ function JobsPage() {
     return <span className="text-zinc-600">—</span>;
   };
 
-  const navigateToJob = (jobId: string, jobQueueName: string) => {
+  const navigateToJob = (
+    jobId: string,
+    jobQueueName: string,
+    jobPrefix?: string,
+  ) => {
     navigate({
       to: "/jobs/$jobId",
       params: { jobId },
-      search: { queueName: jobQueueName },
+      search: {
+        queueName: jobQueueName,
+        prefix: jobPrefix,
+      },
     });
   };
 
@@ -238,20 +279,29 @@ function JobsPage() {
       {/* Header Controls */}
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex flex-wrap items-center gap-3">
-          {/* Queue Selector */}
           <Select
-            value={queueName || ALL_QUEUES_VALUE}
+            value={
+              selectedQueue || ALL_QUEUES_VALUE
+            }
             onValueChange={(value) =>
-              setQueueName(value === ALL_QUEUES_VALUE ? "" : value)
+              setSelectedQueue(
+                value === ALL_QUEUES_VALUE
+                  ? ""
+                  : value,
+              )
             }
             disabled={loadingQueues}
           >
-            <SelectTrigger className="w-[200px] bg-zinc-900 border-zinc-800">
+            <SelectTrigger className="w-[250px] bg-zinc-900 border-zinc-800">
               <Layers className="size-4 mr-2 text-zinc-500" />
               <SelectValue placeholder="Select queue" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={ALL_QUEUES_VALUE}>All queues</SelectItem>
+              <SelectItem
+                value={ALL_QUEUES_VALUE}
+              >
+                All queues
+              </SelectItem>
               {loadingQueues ? (
                 <div className="p-2">
                   <Skeleton className="h-8 w-full" />
@@ -262,8 +312,24 @@ function JobsPage() {
                 </div>
               ) : (
                 queues?.map((queue) => (
-                  <SelectItem key={queue.name} value={queue.name}>
-                    <span className="font-mono">{queue.name}</span>
+                  <SelectItem
+                    key={queueKey(
+                      queue.prefix,
+                      queue.name,
+                    )}
+                    value={queueKey(
+                      queue.prefix,
+                      queue.name,
+                    )}
+                  >
+                    <span className="font-mono">
+                      {hasMultiplePrefixes && (
+                        <span className="text-zinc-500 mr-1">
+                          {queue.prefix}/
+                        </span>
+                      )}
+                      {queue.name}
+                    </span>
                   </SelectItem>
                 ))
               )}
@@ -387,7 +453,7 @@ function JobsPage() {
                 <TableRow
                   key={`${job.queueName}-${job.id}`}
                   className="border-zinc-800 cursor-pointer hover:bg-zinc-800/50 transition-colors"
-                  onClick={() => navigateToJob(job.id, job.queueName)}
+                  onClick={() => navigateToJob(job.id, job.queueName, job.prefix)}
                 >
                   <TableCell>
                     <div className="flex flex-col">

--- a/apps/cli/src/routes/jobs/index.tsx
+++ b/apps/cli/src/routes/jobs/index.tsx
@@ -58,27 +58,10 @@ const BASE_STATUS_TABS: { value: FilterableStatus | "all"; label: string }[] = [
   { value: "delayed", label: "Delayed" },
 ];
 
+import { queueKey, parseQueueKey } from "@/lib/queue-key";
+
 const ALL_QUEUES_VALUE = "__all__";
 const SEARCH_DEBOUNCE_MS = 300;
-const COMPOSITE_SEP = "::";
-
-function queueKey(
-  prefix: string,
-  name: string,
-): string {
-  return `${prefix}${COMPOSITE_SEP}${name}`;
-}
-
-function parseQueueKey(
-  key: string,
-): { prefix: string; name: string } | null {
-  const idx = key.indexOf(COMPOSITE_SEP);
-  if (idx === -1) return null;
-  return {
-    prefix: key.slice(0, idx),
-    name: key.slice(idx + COMPOSITE_SEP.length),
-  };
-}
 
 function useDebounce<T>(value: T, delay: number): T {
   const [debouncedValue, setDebouncedValue] = useState<T>(value);

--- a/packages/connect-types/src/flow.ts
+++ b/packages/connect-types/src/flow.ts
@@ -17,6 +17,7 @@ export interface FlowSummary {
   id: string;
   name: string;
   queueName: string;
+  prefix?: string;
   status: JobStatus;
   totalJobs: number;
   completedJobs: number;

--- a/packages/connect-types/src/job.ts
+++ b/packages/connect-types/src/job.ts
@@ -11,6 +11,7 @@ export interface Job {
   id: string;
   name: string;
   queueName: string;
+  prefix?: string;
   data: unknown;
   status: JobStatus;
   progress: number | object;
@@ -56,6 +57,7 @@ export interface JobSummary {
   id: string;
   name: string;
   queueName: string;
+  prefix?: string;
   status: JobStatus;
   progress: number | object;
   attemptsMade: number;

--- a/packages/connect-types/src/queue.ts
+++ b/packages/connect-types/src/queue.ts
@@ -11,6 +11,7 @@ export interface JobCounts {
 
 export interface Queue {
   name: string;
+  prefix: string;
   isPaused: boolean;
   jobCounts: JobCounts;
 }

--- a/packages/queue/src/detection/index.ts
+++ b/packages/queue/src/detection/index.ts
@@ -1,1 +1,2 @@
 export { detectProvider, type ProviderDetectionResult } from "./provider-detector";
+export { discoverPrefixes } from "./prefix-discovery";

--- a/packages/queue/src/detection/prefix-discovery.ts
+++ b/packages/queue/src/detection/prefix-discovery.ts
@@ -17,12 +17,15 @@ export async function discoverPrefixes(
   return Array.from(prefixes).sort();
 }
 
+const MAX_SCAN_ITERATIONS = 10_000;
+
 async function scanForPattern(
   redis: Redis,
   pattern: string,
   out: Set<string>,
 ): Promise<void> {
   let cursor = "0";
+  let iterations = 0;
   do {
     const [next, keys] = await redis.scan(
       cursor,
@@ -35,6 +38,14 @@ async function scanForPattern(
     for (const key of keys) {
       const prefix = key.split(":")[0];
       if (prefix) out.add(prefix);
+    }
+    iterations++;
+    if (iterations >= MAX_SCAN_ITERATIONS) {
+      console.warn(
+        `[PrefixDiscovery] Stopped after ` +
+          `${MAX_SCAN_ITERATIONS} iterations`,
+      );
+      break;
     }
   } while (cursor !== "0");
 }

--- a/packages/queue/src/detection/prefix-discovery.ts
+++ b/packages/queue/src/detection/prefix-discovery.ts
@@ -1,0 +1,40 @@
+import type Redis from "ioredis";
+
+/**
+ * Discover all Bull/BullMQ prefixes in a Redis instance
+ * by scanning for known key patterns:
+ *   - BullMQ: `<prefix>:<queue>:meta`
+ *   - Bull:   `<prefix>:<queue>:id`
+ */
+export async function discoverPrefixes(
+  redis: Redis,
+): Promise<string[]> {
+  const prefixes = new Set<string>();
+
+  await scanForPattern(redis, "*:*:meta", prefixes);
+  await scanForPattern(redis, "*:*:id", prefixes);
+
+  return Array.from(prefixes).sort();
+}
+
+async function scanForPattern(
+  redis: Redis,
+  pattern: string,
+  out: Set<string>,
+): Promise<void> {
+  let cursor = "0";
+  do {
+    const [next, keys] = await redis.scan(
+      cursor,
+      "MATCH",
+      pattern,
+      "COUNT",
+      200,
+    );
+    cursor = next;
+    for (const key of keys) {
+      const prefix = key.split(":")[0];
+      if (prefix) out.add(prefix);
+    }
+  } while (cursor !== "0");
+}

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -25,8 +25,7 @@ export { BullMqProvider, BullProvider } from "./providers";
 export { createQueueProvider, createProviderByType } from "./providers/provider-factory";
 
 // Detection
-export { detectProvider, type ProviderDetectionResult } from "./detection";
-export { discoverPrefixes } from "./detection";
+export { detectProvider, discoverPrefixes, type ProviderDetectionResult } from "./detection";
 
 // Errors
 export * from "./errors";

--- a/packages/queue/src/index.ts
+++ b/packages/queue/src/index.ts
@@ -26,6 +26,7 @@ export { createQueueProvider, createProviderByType } from "./providers/provider-
 
 // Detection
 export { detectProvider, type ProviderDetectionResult } from "./detection";
+export { discoverPrefixes } from "./detection";
 
 // Errors
 export * from "./errors";

--- a/packages/queue/src/providers/bull/bull-provider.ts
+++ b/packages/queue/src/providers/bull/bull-provider.ts
@@ -22,8 +22,12 @@ import { getProviderCapabilities } from "../../types";
 
 const DEFAULT_PREFIX = "bull";
 
-// Bull-specific job states (no prioritized, no waiting-children, no paused per-job)
-type BullJobStatus = "waiting" | "active" | "completed" | "failed" | "delayed";
+type BullJobStatus =
+  | "waiting"
+  | "active"
+  | "completed"
+  | "failed"
+  | "delayed";
 
 export class BullProvider implements QueueService {
   readonly providerType: QueueProviderType = "bull";
@@ -41,6 +45,48 @@ export class BullProvider implements QueueService {
       ...config,
     };
     this.eventCallbacks = config.eventCallbacks ?? {};
+  }
+
+  private resolvedPrefixes: string[] | null = null;
+
+  private queueKey(
+    prefix: string, name: string,
+  ): string {
+    return `${prefix}\0${name}`;
+  }
+
+  private get defaultPrefix(): string {
+    return this.config.prefix ?? DEFAULT_PREFIX;
+  }
+
+  private async getActivePrefixes(): Promise<string[]> {
+    if (this.resolvedPrefixes) {
+      return this.resolvedPrefixes;
+    }
+    const explicit = this.config.prefixes;
+    if (
+      explicit &&
+      explicit.length > 0 &&
+      !explicit.includes("*")
+    ) {
+      this.resolvedPrefixes = explicit;
+      return explicit;
+    }
+    if (
+      explicit?.includes("*") &&
+      this.connection
+    ) {
+      const { discoverPrefixes } =
+        await import("../../detection/prefix-discovery");
+      const found = await discoverPrefixes(
+        this.connection,
+      );
+      this.resolvedPrefixes =
+        found.length > 0 ? found : [this.defaultPrefix];
+      return this.resolvedPrefixes;
+    }
+    this.resolvedPrefixes = [this.defaultPrefix];
+    return this.resolvedPrefixes;
   }
 
   getCapabilities(): QueueProviderCapabilities {
@@ -144,30 +190,49 @@ export class BullProvider implements QueueService {
     return this._isConnected && this.connection?.status === "ready";
   }
 
-  async getQueues(): Promise<IQueue[]> {
-    const queueNames = await this.discoverQueues();
-    const queues = await Promise.all(
-      queueNames.map((name) => this.getQueue(name)),
-    );
-    return queues.filter((q): q is IQueue => q !== null);
+  async getPrefixes(): Promise<string[]> {
+    return this.getActivePrefixes();
   }
 
-  async getQueue(name: string): Promise<IQueue | null> {
-    const queue = this.getOrCreateQueue(name);
+  async getQueues(): Promise<IQueue[]> {
+    const discovered = await this.discoverQueues();
+    const queues = await Promise.all(
+      discovered.map((q) =>
+        this.getQueue(q.name, q.prefix),
+      ),
+    );
+    return queues.filter(
+      (q): q is IQueue => q !== null,
+    );
+  }
+
+  async getQueue(
+    name: string,
+    prefix?: string,
+  ): Promise<IQueue | null> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(name, pfx);
     const [isPaused, jobCounts] = await Promise.all([
       queue.isPaused(),
-      this.getJobCounts(name),
+      this.getJobCounts(name, pfx),
     ]);
 
     return {
       name,
+      prefix: pfx,
       isPaused,
       jobCounts,
     };
   }
 
-  async getJobCounts(queueName: string): Promise<JobCounts> {
-    const queue = this.getOrCreateQueue(queueName);
+  async getJobCounts(
+    queueName: string,
+    prefix?: string,
+  ): Promise<JobCounts> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const counts = await queue.getJobCounts();
     // Bull's JobCounts only has: active, completed, failed, delayed, waiting
     // Paused jobs are in the 'waiting' count but queue itself can be paused
@@ -185,18 +250,35 @@ export class BullProvider implements QueueService {
     };
   }
 
-  async pauseQueue(queueName: string): Promise<void> {
-    const queue = this.getOrCreateQueue(queueName);
+  async pauseQueue(
+    queueName: string, prefix?: string,
+  ): Promise<void> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     await queue.pause();
   }
 
-  async resumeQueue(queueName: string): Promise<void> {
-    const queue = this.getOrCreateQueue(queueName);
+  async resumeQueue(
+    queueName: string, prefix?: string,
+  ): Promise<void> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     await queue.resume();
   }
 
-  async getJobs(queueName: string, options?: JobQueryOptions): Promise<Job[]> {
-    const queue = this.getOrCreateQueue(queueName);
+  async getJobs(
+    queueName: string,
+    options?: JobQueryOptions,
+    prefix?: string,
+  ): Promise<Job[]> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const { filter, sort, limit = 100, offset = 0 } = options ?? {};
 
     const statuses = this.resolveStatuses(filter?.status);
@@ -222,10 +304,11 @@ export class BullProvider implements QueueService {
   async getJobsSummary(
     queueName: string,
     options?: JobQueryOptions,
+    prefix?: string,
   ): Promise<JobSummary[]> {
-    // Bull doesn't have an efficient metadata-only fetch like BullMQ
-    // Fall back to full job fetching and map to summary
-    const jobs = await this.getJobs(queueName, options);
+    const jobs = await this.getJobs(
+      queueName, options, prefix,
+    );
     return jobs.map((job) => ({
       id: job.id,
       name: job.name,
@@ -244,8 +327,15 @@ export class BullProvider implements QueueService {
     }));
   }
 
-  async getJob(queueName: string, jobId: string): Promise<Job | null> {
-    const queue = this.getOrCreateQueue(queueName);
+  async getJob(
+    queueName: string,
+    jobId: string,
+    prefix?: string,
+  ): Promise<Job | null> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const job = await queue.getJob(jobId);
     if (!job) {
       return null;
@@ -257,13 +347,24 @@ export class BullProvider implements QueueService {
   async getJobLogs(
     queueName: string,
     jobId: string,
+    prefix?: string,
   ): Promise<{ logs: string[]; count: number }> {
-    const queue = this.getOrCreateQueue(queueName);
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     return queue.getJobLogs(jobId);
   }
 
-  async retryJob(queueName: string, jobId: string): Promise<void> {
-    const queue = this.getOrCreateQueue(queueName);
+  async retryJob(
+    queueName: string,
+    jobId: string,
+    prefix?: string,
+  ): Promise<void> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const job = await queue.getJob(jobId);
 
     if (!job) {
@@ -273,8 +374,15 @@ export class BullProvider implements QueueService {
     await job.retry();
   }
 
-  async removeJob(queueName: string, jobId: string): Promise<void> {
-    const queue = this.getOrCreateQueue(queueName);
+  async removeJob(
+    queueName: string,
+    jobId: string,
+    prefix?: string,
+  ): Promise<void> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const job = await queue.getJob(jobId);
 
     if (!job) {
@@ -284,8 +392,14 @@ export class BullProvider implements QueueService {
     await job.remove();
   }
 
-  async getWorkerCount(queueName: string): Promise<WorkerCount> {
-    const queue = this.getOrCreateQueue(queueName);
+  async getWorkerCount(
+    queueName: string,
+    prefix?: string,
+  ): Promise<WorkerCount> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const workers = await queue.getWorkers();
 
     return {
@@ -294,18 +408,19 @@ export class BullProvider implements QueueService {
     };
   }
 
-  private getOrCreateQueue(name: string): Bull.Queue {
-    let queue = this.queues.get(name);
+  private getOrCreateQueue(
+    name: string,
+    prefix: string,
+  ): Bull.Queue {
+    const key = this.queueKey(prefix, name);
+    let queue = this.queues.get(key);
     if (!queue) {
       if (!this.connection) {
         throw new NotConnectedError();
       }
 
-      // Bull uses createClient for connection reuse
       queue = new Bull(name, {
         createClient: (type) => {
-          // Reuse existing connection for client type
-          // Create new connections for subscriber and bclient (blocking client)
           if (type === "client") {
             return this.connection!.duplicate();
           }
@@ -314,44 +429,52 @@ export class BullProvider implements QueueService {
             enableReadyCheck: true,
           });
         },
-        prefix: this.config.prefix,
+        prefix,
       });
-      this.queues.set(name, queue);
+      this.queues.set(key, queue);
     }
     return queue;
   }
 
-  private async discoverQueues(): Promise<string[]> {
+  private async discoverQueues(): Promise<
+    { name: string; prefix: string }[]
+  > {
     if (!this.connection) {
       throw new NotConnectedError();
     }
 
-    const prefix = this.config.prefix ?? DEFAULT_PREFIX;
-    // Bull stores job ID counter in bull:queueName:id
-    const pattern = `${prefix}:*:id`;
-    const keys: string[] = [];
-    let cursor = "0";
+    const prefixes = await this.getActivePrefixes();
+    const result: { name: string; prefix: string }[] =
+      [];
+    const seen = new Set<string>();
 
-    do {
-      const [nextCursor, results] = await this.connection.scan(
-        cursor,
-        "MATCH",
-        pattern,
-        "COUNT",
-        100,
-      );
-      cursor = nextCursor;
-      keys.push(...results);
-    } while (cursor !== "0");
+    for (const prefix of prefixes) {
+      const pattern = `${prefix}:*:id`;
+      let cursor = "0";
+      do {
+        const [next, keys] =
+          await this.connection.scan(
+            cursor,
+            "MATCH",
+            pattern,
+            "COUNT",
+            100,
+          );
+        cursor = next;
+        for (const key of keys) {
+          const parts = key.split(":");
+          const name = parts[1] ?? "";
+          if (!name) continue;
+          const composite =
+            this.queueKey(prefix, name);
+          if (seen.has(composite)) continue;
+          seen.add(composite);
+          result.push({ name, prefix });
+        }
+      } while (cursor !== "0");
+    }
 
-    const queueNames = keys
-      .map((key) => {
-        const parts = key.split(":");
-        return parts[1] ?? "";
-      })
-      .filter(Boolean);
-
-    return [...new Set(queueNames)];
+    return result;
   }
 
   private resolveStatuses(status?: JobStatus | JobStatus[]): BullJobStatus[] {

--- a/packages/queue/src/providers/bull/bull-provider.ts
+++ b/packages/queue/src/providers/bull/bull-provider.ts
@@ -19,6 +19,7 @@ import type {
 } from "@bullstudio/connect-types";
 import { NotConnectedError, JobNotFoundError } from "../../errors";
 import { getProviderCapabilities } from "../../types";
+import { discoverPrefixes } from "../../detection/prefix-discovery";
 
 const DEFAULT_PREFIX = "bull";
 
@@ -56,7 +57,17 @@ export class BullProvider implements QueueService {
   }
 
   private get defaultPrefix(): string {
-    return this.config.prefix ?? DEFAULT_PREFIX;
+    if (this.config.prefix) {
+      return this.config.prefix;
+    }
+    const explicit =
+      this.config.prefixes?.filter(
+        (p) => p !== "*",
+      );
+    if (explicit?.length === 1) {
+      return explicit[0]!;
+    }
+    return DEFAULT_PREFIX;
   }
 
   private async getActivePrefixes(): Promise<string[]> {
@@ -76,13 +87,13 @@ export class BullProvider implements QueueService {
       explicit?.includes("*") &&
       this.connection
     ) {
-      const { discoverPrefixes } =
-        await import("../../detection/prefix-discovery");
       const found = await discoverPrefixes(
         this.connection,
       );
       this.resolvedPrefixes =
-        found.length > 0 ? found : [this.defaultPrefix];
+        found.length > 0
+          ? found
+          : [this.defaultPrefix];
       return this.resolvedPrefixes;
     }
     this.resolvedPrefixes = [this.defaultPrefix];

--- a/packages/queue/src/providers/bullmq/bullmq-provider.ts
+++ b/packages/queue/src/providers/bullmq/bullmq-provider.ts
@@ -39,6 +39,48 @@ export class BullMqProvider implements QueueService {
     this.eventCallbacks = config.eventCallbacks ?? {};
   }
 
+  private resolvedPrefixes: string[] | null = null;
+
+  private queueKey(
+    prefix: string, name: string,
+  ): string {
+    return `${prefix}\0${name}`;
+  }
+
+  private get defaultPrefix(): string {
+    return this.config.prefix ?? DEFAULT_PREFIX;
+  }
+
+  private async getActivePrefixes(): Promise<string[]> {
+    if (this.resolvedPrefixes) {
+      return this.resolvedPrefixes;
+    }
+    const explicit = this.config.prefixes;
+    if (
+      explicit &&
+      explicit.length > 0 &&
+      !explicit.includes("*")
+    ) {
+      this.resolvedPrefixes = explicit;
+      return explicit;
+    }
+    if (
+      explicit?.includes("*") &&
+      this.connection
+    ) {
+      const { discoverPrefixes } =
+        await import("../../detection/prefix-discovery");
+      const found = await discoverPrefixes(
+        this.connection,
+      );
+      this.resolvedPrefixes =
+        found.length > 0 ? found : [this.defaultPrefix];
+      return this.resolvedPrefixes;
+    }
+    this.resolvedPrefixes = [this.defaultPrefix];
+    return this.resolvedPrefixes;
+  }
+
   getCapabilities(): QueueProviderCapabilities {
     return getProviderCapabilities("bullmq");
   }
@@ -140,30 +182,47 @@ export class BullMqProvider implements QueueService {
     return this._isConnected && this.connection?.status === "ready";
   }
 
-  async getQueues(): Promise<IQueue[]> {
-    const queueNames = await this.discoverQueues();
-    const queues = await Promise.all(
-      queueNames.map((name) => this.getQueue(name)),
-    );
-    return queues.filter((q): q is IQueue => q !== null);
+  async getPrefixes(): Promise<string[]> {
+    return this.getActivePrefixes();
   }
 
-  async getQueue(name: string): Promise<IQueue | null> {
-    const queue = this.getOrCreateQueue(name);
+  async getQueues(): Promise<IQueue[]> {
+    const discovered = await this.discoverQueues();
+    const queues = await Promise.all(
+      discovered.map((q) =>
+        this.getQueue(q.name, q.prefix),
+      ),
+    );
+    return queues.filter(
+      (q): q is IQueue => q !== null,
+    );
+  }
+
+  async getQueue(
+    name: string,
+    prefix?: string,
+  ): Promise<IQueue | null> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(name, pfx);
     const [isPaused, jobCounts] = await Promise.all([
       queue.isPaused(),
-      this.getJobCounts(name),
+      this.getJobCounts(name, pfx),
     ]);
 
     return {
       name,
+      prefix: pfx,
       isPaused,
       jobCounts,
     };
   }
 
-  async getJobCounts(queueName: string): Promise<JobCounts> {
-    const queue = this.getOrCreateQueue(queueName);
+  async getJobCounts(
+    queueName: string,
+    prefix?: string,
+  ): Promise<JobCounts> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(queueName, pfx);
     const counts = await queue.getJobCounts(
       "waiting",
       "active",
@@ -187,18 +246,35 @@ export class BullMqProvider implements QueueService {
     };
   }
 
-  async pauseQueue(queueName: string): Promise<void> {
-    const queue = this.getOrCreateQueue(queueName);
+  async pauseQueue(
+    queueName: string, prefix?: string,
+  ): Promise<void> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     await queue.pause();
   }
 
-  async resumeQueue(queueName: string): Promise<void> {
-    const queue = this.getOrCreateQueue(queueName);
+  async resumeQueue(
+    queueName: string, prefix?: string,
+  ): Promise<void> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     await queue.resume();
   }
 
-  async getJobs(queueName: string, options?: JobQueryOptions): Promise<Job[]> {
-    const queue = this.getOrCreateQueue(queueName);
+  async getJobs(
+    queueName: string,
+    options?: JobQueryOptions,
+    prefix?: string,
+  ): Promise<Job[]> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const { filter, sort, limit = 100, offset = 0 } = options ?? {};
 
     const statuses = this.resolveStatuses(filter?.status);
@@ -329,8 +405,12 @@ export class BullMqProvider implements QueueService {
   async getJobsSummary(
     queueName: string,
     options?: JobQueryOptions,
+    prefix?: string,
   ): Promise<JobSummary[]> {
-    const queue = this.getOrCreateQueue(queueName);
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const { filter, sort, limit = 100, offset = 0 } = options ?? {};
 
     const statuses = this.resolveStatuses(filter?.status);
@@ -354,8 +434,15 @@ export class BullMqProvider implements QueueService {
     return mappedJobs;
   }
 
-  async getJob(queueName: string, jobId: string): Promise<Job | null> {
-    const queue = this.getOrCreateQueue(queueName);
+  async getJob(
+    queueName: string,
+    jobId: string,
+    prefix?: string,
+  ): Promise<Job | null> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const job = await queue.getJob(jobId);
     if (!job) {
       return null;
@@ -368,13 +455,24 @@ export class BullMqProvider implements QueueService {
   async getJobLogs(
     queueName: string,
     jobId: string,
+    prefix?: string,
   ): Promise<{ logs: string[]; count: number }> {
-    const queue = this.getOrCreateQueue(queueName);
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     return queue.getJobLogs(jobId);
   }
 
-  async retryJob(queueName: string, jobId: string): Promise<void> {
-    const queue = this.getOrCreateQueue(queueName);
+  async retryJob(
+    queueName: string,
+    jobId: string,
+    prefix?: string,
+  ): Promise<void> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const job = await queue.getJob(jobId);
 
     if (!job) {
@@ -384,8 +482,15 @@ export class BullMqProvider implements QueueService {
     await job.retry();
   }
 
-  async removeJob(queueName: string, jobId: string): Promise<void> {
-    const queue = this.getOrCreateQueue(queueName);
+  async removeJob(
+    queueName: string,
+    jobId: string,
+    prefix?: string,
+  ): Promise<void> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const job = await queue.getJob(jobId);
 
     if (!job) {
@@ -395,8 +500,14 @@ export class BullMqProvider implements QueueService {
     await job.remove();
   }
 
-  async getWorkerCount(queueName: string): Promise<WorkerCount> {
-    const queue = this.getOrCreateQueue(queueName);
+  async getWorkerCount(
+    queueName: string,
+    prefix?: string,
+  ): Promise<WorkerCount> {
+    const pfx = prefix ?? this.defaultPrefix;
+    const queue = this.getOrCreateQueue(
+      queueName, pfx,
+    );
     const workers = await queue.getWorkers();
 
     return {
@@ -405,51 +516,64 @@ export class BullMqProvider implements QueueService {
     };
   }
 
-  private getOrCreateQueue(name: string): Queue {
-    let queue = this.queues.get(name);
+  private getOrCreateQueue(
+    name: string,
+    prefix: string,
+  ): Queue {
+    const key = this.queueKey(prefix, name);
+    let queue = this.queues.get(key);
     if (!queue) {
       if (!this.connection) {
         throw new NotConnectedError();
       }
       queue = new Queue(name, {
         connection: this.connection,
-        prefix: this.config.prefix,
+        prefix,
       });
-      this.queues.set(name, queue);
+      this.queues.set(key, queue);
     }
     return queue;
   }
 
-  private async discoverQueues(): Promise<string[]> {
+  private async discoverQueues(): Promise<
+    { name: string; prefix: string }[]
+  > {
     if (!this.connection) {
       throw new NotConnectedError();
     }
 
-    const prefix = this.config.prefix ?? DEFAULT_PREFIX;
-    const pattern = `${prefix}:*:meta`;
-    const keys: string[] = [];
-    let cursor = "0";
+    const prefixes = await this.getActivePrefixes();
+    const result: { name: string; prefix: string }[] =
+      [];
+    const seen = new Set<string>();
 
-    do {
-      const [nextCursor, results] = await this.connection.scan(
-        cursor,
-        "MATCH",
-        pattern,
-        "COUNT",
-        100,
-      );
-      cursor = nextCursor;
-      keys.push(...results);
-    } while (cursor !== "0");
+    for (const prefix of prefixes) {
+      const pattern = `${prefix}:*:meta`;
+      let cursor = "0";
+      do {
+        const [next, keys] =
+          await this.connection.scan(
+            cursor,
+            "MATCH",
+            pattern,
+            "COUNT",
+            100,
+          );
+        cursor = next;
+        for (const key of keys) {
+          const parts = key.split(":");
+          const name = parts[1] ?? "";
+          if (!name) continue;
+          const composite =
+            this.queueKey(prefix, name);
+          if (seen.has(composite)) continue;
+          seen.add(composite);
+          result.push({ name, prefix });
+        }
+      } while (cursor !== "0");
+    }
 
-    const queueNames = keys
-      .map((key) => {
-        const parts = key.split(":");
-        return parts[1] ?? "";
-      })
-      .filter(Boolean);
-
-    return [...new Set(queueNames)];
+    return result;
   }
 
   private resolveStatuses(

--- a/packages/queue/src/providers/bullmq/bullmq-provider.ts
+++ b/packages/queue/src/providers/bullmq/bullmq-provider.ts
@@ -18,6 +18,7 @@ import type {
   WorkerCount,
 } from "@bullstudio/connect-types";
 import { NotConnectedError, JobNotFoundError } from "../../errors";
+import { discoverPrefixes } from "../../detection/prefix-discovery";
 
 const DEFAULT_PREFIX = "bull";
 
@@ -48,7 +49,17 @@ export class BullMqProvider implements QueueService {
   }
 
   private get defaultPrefix(): string {
-    return this.config.prefix ?? DEFAULT_PREFIX;
+    if (this.config.prefix) {
+      return this.config.prefix;
+    }
+    const explicit =
+      this.config.prefixes?.filter(
+        (p) => p !== "*",
+      );
+    if (explicit?.length === 1) {
+      return explicit[0]!;
+    }
+    return DEFAULT_PREFIX;
   }
 
   private async getActivePrefixes(): Promise<string[]> {
@@ -68,13 +79,13 @@ export class BullMqProvider implements QueueService {
       explicit?.includes("*") &&
       this.connection
     ) {
-      const { discoverPrefixes } =
-        await import("../../detection/prefix-discovery");
       const found = await discoverPrefixes(
         this.connection,
       );
       this.resolvedPrefixes =
-        found.length > 0 ? found : [this.defaultPrefix];
+        found.length > 0
+          ? found
+          : [this.defaultPrefix];
       return this.resolvedPrefixes;
     }
     this.resolvedPrefixes = [this.defaultPrefix];

--- a/packages/queue/src/providers/provider-factory.ts
+++ b/packages/queue/src/providers/provider-factory.ts
@@ -22,27 +22,36 @@ export async function createQueueProvider(
     retryStrategy: () => null,
   });
 
+  let finalConfig: QueueServiceConfig = {
+    ...config,
+  };
+
   try {
     await redis.connect();
 
     let prefixes = config.prefixes;
 
     if (prefixes?.includes("*")) {
-      const found = await discoverPrefixes(redis);
+      const found =
+        await discoverPrefixes(redis);
       if (found.length > 0) {
         prefixes = found;
         console.log(
-          `[ProviderFactory] Discovered prefixes: ${found.join(", ")}`,
+          `[ProviderFactory] Discovered ` +
+            `prefixes: ${found.join(", ")}`,
         );
       } else {
         prefixes = [config.prefix ?? "bull"];
       }
     }
 
+    finalConfig = { ...config, prefixes };
+
     const detectionPrefix =
       prefixes?.[0] ?? config.prefix ?? "bull";
     const detection = await detectProvider(
-      redis, detectionPrefix,
+      redis,
+      detectionPrefix,
     );
 
     console.log(
@@ -52,19 +61,16 @@ export async function createQueueProvider(
         `from ${detection.detectedFrom})`,
     );
 
-    const finalConfig: QueueServiceConfig = {
-      ...config,
-      prefixes,
-    };
-
     return createProviderByType(
-      detection.type, finalConfig,
+      detection.type,
+      finalConfig,
     );
   } catch (error) {
     console.error(
-      "[ProviderFactory] Detection failed:", error,
+      "[ProviderFactory] Detection failed:",
+      error,
     );
-    return new BullMqProvider(config);
+    return new BullMqProvider(finalConfig);
   } finally {
     await redis.quit().catch(() => {});
   }

--- a/packages/queue/src/providers/provider-factory.ts
+++ b/packages/queue/src/providers/provider-factory.ts
@@ -1,17 +1,21 @@
 import Redis from "ioredis";
-import type { QueueService, QueueServiceConfig, QueueProviderType } from "../types";
+import type {
+  QueueService,
+  QueueServiceConfig,
+  QueueProviderType,
+} from "../types";
 import { BullMqProvider } from "./bullmq";
 import { BullProvider } from "./bull";
-import { detectProvider } from "../detection";
+import { detectProvider, discoverPrefixes } from "../detection";
 
 /**
  * Auto-detect and create appropriate queue provider.
- * Detection happens once per connection by scanning Redis keys.
+ * When `prefixes: ["*"]` is set, discovers all
+ * prefixes before detecting the provider type.
  */
 export async function createQueueProvider(
-  config: QueueServiceConfig
+  config: QueueServiceConfig,
 ): Promise<QueueService> {
-  // Create temporary Redis connection for detection
   const redis = new Redis(config.redisUrl, {
     maxRetriesPerRequest: null,
     lazyConnect: true,
@@ -21,22 +25,47 @@ export async function createQueueProvider(
   try {
     await redis.connect();
 
-    // Detect provider type
-    const detection = await detectProvider(redis, config.prefix ?? "bull");
+    let prefixes = config.prefixes;
 
-    console.log(
-      `[ProviderFactory] Detected provider: ${detection.type} (${detection.confidence} confidence from ${detection.detectedFrom})`
+    if (prefixes?.includes("*")) {
+      const found = await discoverPrefixes(redis);
+      if (found.length > 0) {
+        prefixes = found;
+        console.log(
+          `[ProviderFactory] Discovered prefixes: ${found.join(", ")}`,
+        );
+      } else {
+        prefixes = [config.prefix ?? "bull"];
+      }
+    }
+
+    const detectionPrefix =
+      prefixes?.[0] ?? config.prefix ?? "bull";
+    const detection = await detectProvider(
+      redis, detectionPrefix,
     );
 
-    // Create appropriate provider
-    return createProviderByType(detection.type, config);
-  } catch (error) {
-    console.error("[ProviderFactory] Detection failed:", error);
+    console.log(
+      `[ProviderFactory] Detected provider: ` +
+        `${detection.type} ` +
+        `(${detection.confidence} confidence ` +
+        `from ${detection.detectedFrom})`,
+    );
 
-    // Default to BullMQ on error
+    const finalConfig: QueueServiceConfig = {
+      ...config,
+      prefixes,
+    };
+
+    return createProviderByType(
+      detection.type, finalConfig,
+    );
+  } catch (error) {
+    console.error(
+      "[ProviderFactory] Detection failed:", error,
+    );
     return new BullMqProvider(config);
   } finally {
-    // Always close the detection connection
     await redis.quit().catch(() => {});
   }
 }

--- a/packages/queue/src/types/queue-service.types.ts
+++ b/packages/queue/src/types/queue-service.types.ts
@@ -28,7 +28,10 @@ export interface QueueServiceEventCallbacks {
  */
 export interface QueueServiceConfig {
   redisUrl: string;
+  /** Single prefix (backward compat). Ignored when prefixes is set. */
   prefix?: string;
+  /** Explicit list of prefixes. Use `["*"]` for auto-discovery. */
+  prefixes?: string[];
   eventCallbacks?: QueueServiceEventCallbacks;
 }
 
@@ -49,29 +52,60 @@ export interface QueueService {
   /** Check if currently connected */
   isConnected(): boolean;
 
+  /** Return all discovered prefixes. */
+  getPrefixes(): Promise<string[]>;
+
   // Queue operations
   getQueues(): Promise<Queue[]>;
-  getQueue(name: string): Promise<Queue | null>;
-  pauseQueue(queueName: string): Promise<void>;
-  resumeQueue(queueName: string): Promise<void>;
-  getJobCounts(queueName: string): Promise<JobCounts>;
+  getQueue(
+    name: string, prefix?: string,
+  ): Promise<Queue | null>;
+  pauseQueue(
+    queueName: string, prefix?: string,
+  ): Promise<void>;
+  resumeQueue(
+    queueName: string, prefix?: string,
+  ): Promise<void>;
+  getJobCounts(
+    queueName: string, prefix?: string,
+  ): Promise<JobCounts>;
 
   // Job operations
-  getJobs(queueName: string, options?: JobQueryOptions): Promise<Job[]>;
+  getJobs(
+    queueName: string,
+    options?: JobQueryOptions,
+    prefix?: string,
+  ): Promise<Job[]>;
   getJobsSummary(
     queueName: string,
     options?: JobQueryOptions,
+    prefix?: string,
   ): Promise<JobSummary[]>;
-  getJob(queueName: string, jobId: string): Promise<Job | null>;
+  getJob(
+    queueName: string,
+    jobId: string,
+    prefix?: string,
+  ): Promise<Job | null>;
   getJobLogs(
     queueName: string,
     jobId: string,
+    prefix?: string,
   ): Promise<{ logs: string[]; count: number }>;
-  retryJob(queueName: string, jobId: string): Promise<void>;
-  removeJob(queueName: string, jobId: string): Promise<void>;
+  retryJob(
+    queueName: string,
+    jobId: string,
+    prefix?: string,
+  ): Promise<void>;
+  removeJob(
+    queueName: string,
+    jobId: string,
+    prefix?: string,
+  ): Promise<void>;
 
   // Worker operations
-  getWorkerCount(queueName: string): Promise<WorkerCount>;
+  getWorkerCount(
+    queueName: string, prefix?: string,
+  ): Promise<WorkerCount>;
 
   // Provider capabilities
   getCapabilities(): QueueProviderCapabilities;


### PR DESCRIPTION
## Summary

Addresses #1 — adds support for multiple Redis key prefixes and automatic prefix discovery.

- **Auto-discovery**: bullstudio now scans Redis for all Bull/BullMQ prefixes automatically (e.g. `stage`, `stage2`, `bull`), no configuration required
- **Explicit prefixes**: new `--prefix` CLI flag and `REDIS_PREFIX` env var to restrict to specific prefixes (comma-separated)
- **UI prefix labels**: when multiple prefixes are detected, queue selectors display `prefix/queue-name` to disambiguate; the sidebar shows all active prefixes

### Detailed changes

| Layer | What changed |
|-------|-------------|
| `connect-types` | Added `prefix` field to `Queue`, optional `prefix` to `Job`/`JobSummary` |
| `packages/queue` detection | New `discoverPrefixes()` utility scanning `*:*:meta` and `*:*:id` patterns |
| `packages/queue` types | `QueueServiceConfig.prefixes?: string[]`, `getPrefixes()` on `QueueService`, optional `prefix` param on all queue/job methods |
| BullMQ + Bull providers | Track queues keyed by `prefix + name`; `discoverQueues()` iterates all active prefixes; `getOrCreateQueue()` creates instances with the correct prefix |
| Provider factory | Runs prefix discovery when `prefixes: ["*"]` before provider detection |
| CLI (`cli.ts`) | `--prefix` flag, passes `REDIS_PREFIX` env to child process |
| CLI connection | Defaults to `prefixes: ["*"]` (auto-discover); reads `REDIS_PREFIX` env |
| tRPC routers | All queue/job endpoints accept & pass `prefix`; new `queues.prefixes` endpoint |
| UI (Overview, Jobs, Job Detail, Sidebar) | Composite queue keys for selectors, prefix labels, prefix in navigation search params |
| README | Documented `--prefix`, `REDIS_PREFIX`, and examples |

### Backward compatibility

Single-prefix setups (the common case) continue to work identically — the default prefix remains `"bull"` and auto-discovery is transparent.

## Test plan

- [ ] Single prefix Redis instance: verify queues appear as before
- [ ] Multi-prefix Redis instance: verify all prefixes are discovered and queues are grouped correctly
- [ ] `--prefix stage,stage2` restricts to only those prefixes
- [ ] `REDIS_PREFIX=bull` restricts to single prefix
- [ ] Job operations (retry, remove) work correctly across different prefixes
- [ ] Queue pause/resume targets the correct prefix
- [ ] UI shows prefix labels only when multiple prefixes exist

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--prefix` CLI option and `REDIS_PREFIX` env var (comma-separated) with automatic prefix discovery by default.
  * Dashboard now lists discovered prefixes and supports prefix-scoped queue, job and flow selection/navigation.
  * API exposes discovered prefixes; job/flow summaries and queue objects include prefix metadata.

* **Documentation**
  * README, CLI help, usage examples and troubleshooting updated to document multiple-prefix discovery and explicit prefix usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->