### PR TITLE
feat: add Redis server info bar

### DIFF
--- a/apps/cli/src/components/RedisInfoBar.tsx
+++ b/apps/cli/src/components/RedisInfoBar.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useTRPC } from "@/integrations/trpc/react";
+import { useQuery } from "@tanstack/react-query";
+import { Cpu, HardDrive, MemoryStick, Users, Layers } from "lucide-react";
+
+export function RedisInfoBar() {
+  const trpc = useTRPC();
+  const { data } = useQuery(trpc.connection.redisInfo.queryOptions());
+
+  if (!data) return null;
+
+  return (
+    <div className="flex items-center gap-0 border border-zinc-800 rounded-lg bg-zinc-900/50 px-4 py-2.5 text-xs text-zinc-400 divide-x divide-zinc-800 w-fit">
+      {/* Redis icon */}
+      <div className="flex items-center pr-4">
+        <img src="/logo.svg" alt="redis" className="size-5 shrink-0" />
+      </div>
+
+      <InfoItem icon={<Layers className="size-3" />} label="VERSION" value={data.version} />
+      <InfoItem icon={<Cpu className="size-3" />} label="MODE" value={data.mode} />
+      <InfoItem icon={<MemoryStick className="size-3" />} label="USED MEMORY" value={data.usedMemory} />
+      <InfoItem icon={<HardDrive className="size-3" />} label="TOTAL MEMORY" value={data.totalMemory} />
+      <InfoItem
+        icon={<Users className="size-3" />}
+        label="CLIENTS"
+        value={`${data.connectedClients} / ${data.maxClients > 0 ? data.maxClients : "N/A"}`}
+      />
+    </div>
+  );
+}
+
+function InfoItem({
+  icon,
+  label,
+  value,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-4 first:pl-0">
+      <span className="text-zinc-500">{icon}</span>
+      <div className="flex flex-col gap-0.5">
+        <span className="text-[10px] uppercase tracking-wider text-zinc-500 font-medium leading-none">
+          {label}
+        </span>
+        <span className="text-zinc-200 font-medium leading-none">{value}</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/cli/src/integrations/trpc/routers/connection.ts
+++ b/apps/cli/src/integrations/trpc/routers/connection.ts
@@ -25,6 +25,11 @@ function parseRedisUrl(url: string) {
 }
 
 export const connectionRouter = createTRPCRouter({
+  redisInfo: publicProcedure.query(async () => {
+    const provider = await getQueueProvider();
+    return provider.getRedisInfo();
+  }),
+
   info: publicProcedure.query(async () => {
     const redisUrl = getRedisUrl();
     const parsed = parseRedisUrl(redisUrl);

--- a/apps/cli/src/routes/__root.tsx
+++ b/apps/cli/src/routes/__root.tsx
@@ -16,6 +16,7 @@ import {
   SidebarProvider,
 } from "@bullstudio/ui/components/sidebar";
 import { AppSidebar } from "@/components/Sidebar";
+import { RedisInfoBar } from "@/components/RedisInfoBar";
 import { Toaster } from "sonner";
 
 import "../styles.css";
@@ -75,6 +76,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           <SidebarProvider>
             <AppSidebar />
             <SidebarInset className="overflow-y-auto">
+              <div className="px-6 pt-4">
+                <RedisInfoBar />
+              </div>
               <main className="flex-1 p-6">{children}</main>
             </SidebarInset>
             <Scripts />

--- a/packages/queue/src/providers/bull/bull-provider.ts
+++ b/packages/queue/src/providers/bull/bull-provider.ts
@@ -7,6 +7,7 @@ import type {
   QueueServiceConfig,
   QueueServiceEventCallbacks,
   QueueProviderCapabilities,
+  RedisServerInfo,
 } from "../../types";
 import type {
   Job,
@@ -20,7 +21,22 @@ import type {
 import { NotConnectedError, JobNotFoundError } from "../../errors";
 import { getProviderCapabilities } from "../../types";
 
-const DEFAULT_PREFIX = "bull";
+const DEFAULT_PREFIX = "{bullmq}";
+
+function parseRedisInfo(raw: string): RedisServerInfo {
+  const get = (key: string) => {
+    const match = raw.match(new RegExp(`^${key}:(.+)$`, "m"));
+    return match?.[1]?.trim() ?? "";
+  };
+  return {
+    version: get("redis_version"),
+    mode: get("redis_mode") || "standalone",
+    usedMemory: get("used_memory_human"),
+    totalMemory: get("total_system_memory_human"),
+    connectedClients: parseInt(get("connected_clients") || "0", 10),
+    maxClients: parseInt(get("maxclients") || "0", 10),
+  };
+}
 
 // Bull-specific job states (no prioritized, no waiting-children, no paused per-job)
 type BullJobStatus = "waiting" | "active" | "completed" | "failed" | "delayed";
@@ -45,6 +61,12 @@ export class BullProvider implements QueueService {
 
   getCapabilities(): QueueProviderCapabilities {
     return getProviderCapabilities("bull");
+  }
+
+  async getRedisInfo(): Promise<RedisServerInfo> {
+    if (!this.connection) throw new NotConnectedError();
+    const raw = await this.connection.info();
+    return parseRedisInfo(raw);
   }
 
   async connect(): Promise<void> {

--- a/packages/queue/src/providers/bullmq/bullmq-provider.ts
+++ b/packages/queue/src/providers/bullmq/bullmq-provider.ts
@@ -6,6 +6,7 @@ import type {
   QueueServiceConfig,
   QueueServiceEventCallbacks,
   QueueProviderCapabilities,
+  RedisServerInfo,
 } from "../../types";
 import { getProviderCapabilities } from "../../types";
 import type {
@@ -19,7 +20,22 @@ import type {
 } from "@bullstudio/connect-types";
 import { NotConnectedError, JobNotFoundError } from "../../errors";
 
-const DEFAULT_PREFIX = "bull";
+const DEFAULT_PREFIX = "{bullmq}";
+
+function parseRedisInfo(raw: string): RedisServerInfo {
+  const get = (key: string) => {
+    const match = raw.match(new RegExp(`^${key}:(.+)$`, "m"));
+    return match?.[1]?.trim() ?? "";
+  };
+  return {
+    version: get("redis_version"),
+    mode: get("redis_mode") || "standalone",
+    usedMemory: get("used_memory_human"),
+    totalMemory: get("total_system_memory_human"),
+    connectedClients: parseInt(get("connected_clients") || "0", 10),
+    maxClients: parseInt(get("maxclients") || "0", 10),
+  };
+}
 
 export class BullMqProvider implements QueueService {
   readonly providerType: QueueProviderType = "bullmq";
@@ -41,6 +57,12 @@ export class BullMqProvider implements QueueService {
 
   getCapabilities(): QueueProviderCapabilities {
     return getProviderCapabilities("bullmq");
+  }
+
+  async getRedisInfo(): Promise<RedisServerInfo> {
+    if (!this.connection) throw new NotConnectedError();
+    const raw = await this.connection.info();
+    return parseRedisInfo(raw);
   }
 
   async connect(): Promise<void> {

--- a/packages/queue/src/types/index.ts
+++ b/packages/queue/src/types/index.ts
@@ -12,6 +12,7 @@ export type {
   QueueServiceConfig,
   QueueServiceEventCallbacks,
   QueueService,
+  RedisServerInfo,
 } from "./queue-service.types";
 
 export type { QueueProviderCapabilities } from "./provider-capabilities.types";

--- a/packages/queue/src/types/queue-service.types.ts
+++ b/packages/queue/src/types/queue-service.types.ts
@@ -32,6 +32,15 @@ export interface QueueServiceConfig {
   eventCallbacks?: QueueServiceEventCallbacks;
 }
 
+export interface RedisServerInfo {
+  version: string;
+  mode: string;
+  usedMemory: string;
+  totalMemory: string;
+  connectedClients: number;
+  maxClients: number;
+}
+
 /**
  * Abstract interface for queue service providers.
  * Implement this interface to add support for different queue systems.
@@ -72,6 +81,9 @@ export interface QueueService {
 
   // Worker operations
   getWorkerCount(queueName: string): Promise<WorkerCount>;
+
+  // Redis server info
+  getRedisInfo(): Promise<RedisServerInfo>;
 
   // Provider capabilities
   getCapabilities(): QueueProviderCapabilities;


### PR DESCRIPTION
Display Redis version, mode, memory usage, and client count in a pill-shaped bar above the main content area. 
Fetches live data via a new connection.redisInfo tRPC procedure backed by the Redis INFO command on both Bull and BullMQ providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display Redis server information including version, operating mode, memory usage, and client connection details directly in the sidebar for monitoring queue infrastructure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->