### PR TITLE
allow shutdown through sigterm/sigint

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bullstudio",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A lightweight queue management dashboard for Bull and BullMQ",
   "private": false,
   "type": "module",

--- a/apps/cli/server/production.ts
+++ b/apps/cli/server/production.ts
@@ -209,3 +209,19 @@ const server = createServer(async (req, res) => {
 server.listen(port, host, () => {
   console.log(`Server running at http://${host}:${port}`);
 });
+
+const shutdown = (signal: string) => {
+  console.log(`Process received ${signal}, attempting to shut down gracefully`);
+  server.close(() => {
+    console.log('Server stopped succesfully');
+    process.exit(0);
+  });
+
+  setTimeout(() => {
+    console.error('Server stop timeout occurred, forcing shutdown');
+    process.exit(1);
+  }, 10000);
+};
+
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/apps/cli/server/production.ts
+++ b/apps/cli/server/production.ts
@@ -213,7 +213,7 @@ server.listen(port, host, () => {
 const shutdown = (signal: string) => {
   console.log(`Process received ${signal}, attempting to shut down gracefully`);
   server.close(() => {
-    console.log('Server stopped succesfully');
+    console.log('Server stopped successfully');
     process.exit(0);
   });
 

--- a/apps/cli/src/const.ts
+++ b/apps/cli/src/const.ts
@@ -1,1 +1,1 @@
-export const VERSION = "v1.3.0";
+export const VERSION = "v1.4.0";


### PR DESCRIPTION
## Description

When running the container as a single process through docker (so not detached) 

```
docker run -p 4000:4000 -e REDIS_URL=redis://host.docker.internal:6379 emirce/bullstudio
```

The process currently doesn't respect a SIGTERM or SIGINT (Ctrl+C) command, this change allows you to gracefully stop the server directly from the running container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added graceful, signal-driven shutdown handling for process termination.
  * Logs termination signals and shutdown progress, with a 10s timeout that forces exit if shutdown stalls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->