### PR TITLE
fix(queue): support Redis prefixes containing colons

### DIFF
--- a/packages/queue/src/providers/bull/bull-provider.test.ts
+++ b/packages/queue/src/providers/bull/bull-provider.test.ts
@@ -64,6 +64,21 @@ describe("BullProvider (multi-prefix)", () => {
     );
   });
 
+  it("discovers queues when the configured prefix contains colons", async () => {
+    seeded.push(
+      await seedBullQueue({ prefix: "tenant:bull", name: "email" }),
+    );
+
+    await withBullProvider(
+      { prefixes: ["tenant:bull"] },
+      async (provider) => {
+        const queues = await provider.getQueues();
+        expect(queues).toHaveLength(1);
+        expect(queues[0]).toMatchObject({ name: "email", prefix: "tenant:bull" });
+      },
+    );
+  });
+
   it("auto-discovers prefixes from Bull :id marker keys", async () => {
     seeded.push(
       await seedBullQueue({ prefix: "stage", name: "q-s" }),

--- a/packages/queue/src/providers/bull/bull-provider.ts
+++ b/packages/queue/src/providers/bull/bull-provider.ts
@@ -20,6 +20,7 @@ import type {
 import { NotConnectedError, JobNotFoundError } from "../../errors";
 import { getProviderCapabilities } from "../../types";
 import { discoverPrefixes } from "../../detection/prefix-discovery";
+import { parseQueueNameFromKey } from "../redis-key";
 
 const DEFAULT_PREFIX = "bull";
 
@@ -473,8 +474,11 @@ export class BullProvider implements QueueService {
           );
         cursor = next;
         for (const key of keys) {
-          const parts = key.split(":");
-          const name = parts[1] ?? "";
+          const name = parseQueueNameFromKey(
+            key,
+            prefix,
+            "id",
+          );
           if (!name) continue;
           const composite =
             this.queueKey(prefix, name);

--- a/packages/queue/src/providers/bullmq/bullmq-provider.test.ts
+++ b/packages/queue/src/providers/bullmq/bullmq-provider.test.ts
@@ -68,6 +68,24 @@ describe("BullMqProvider (multi-prefix)", () => {
     );
   });
 
+  it("discovers queues when the configured prefix contains colons", async () => {
+    await track(
+      await seedBullMqQueue({ prefix: "tenant:bull", name: "email" }),
+    );
+
+    await withBullMqProvider(
+      { prefixes: ["tenant:bull"] },
+      async (provider) => {
+        const queues = await provider.getQueues();
+        expect(queues).toHaveLength(1);
+        expect(queues[0]).toMatchObject({ name: "email", prefix: "tenant:bull" });
+
+        const counts = await provider.getJobCounts("email", "tenant:bull");
+        expect(counts.waiting).toBe(3);
+      },
+    );
+  });
+
   it("returns queues across multiple explicit prefixes with correct prefix fields", async () => {
     await track(await seedBullMqQueue({ prefix: "a", name: "q1" }));
     await track(await seedBullMqQueue({ prefix: "b", name: "q1" }));

--- a/packages/queue/src/providers/bullmq/bullmq-provider.ts
+++ b/packages/queue/src/providers/bullmq/bullmq-provider.ts
@@ -19,6 +19,7 @@ import type {
 } from "@bullstudio/connect-types";
 import { NotConnectedError, JobNotFoundError } from "../../errors";
 import { discoverPrefixes } from "../../detection/prefix-discovery";
+import { parseQueueNameFromKey } from "../redis-key";
 
 const DEFAULT_PREFIX = "bull";
 
@@ -572,8 +573,11 @@ export class BullMqProvider implements QueueService {
           );
         cursor = next;
         for (const key of keys) {
-          const parts = key.split(":");
-          const name = parts[1] ?? "";
+          const name = parseQueueNameFromKey(
+            key,
+            prefix,
+            "meta",
+          );
           if (!name) continue;
           const composite =
             this.queueKey(prefix, name);

--- a/packages/queue/src/providers/redis-key.ts
+++ b/packages/queue/src/providers/redis-key.ts
@@ -1,0 +1,15 @@
+export function parseQueueNameFromKey(
+  key: string,
+  prefix: string,
+  suffix: string,
+): string | null {
+  const keyPrefix = `${prefix}:`;
+  const keySuffix = `:${suffix}`;
+
+  if (!key.startsWith(keyPrefix) || !key.endsWith(keySuffix)) {
+    return null;
+  }
+
+  const name = key.slice(keyPrefix.length, -keySuffix.length);
+  return name || null;
+}


### PR DESCRIPTION
## Summary

Fix queue discovery when Bull/BullMQ Redis prefixes contain `:` characters, for example `tenant:bull`.

Previously, queue discovery parsed Redis keys with `key.split(":")[1]`. For keys like:

```txt
tenant:bull:email:meta
```

this incorrectly parsed the queue name as `bull` instead of `email`, causing bullstudio to discover the wrong queue and show empty or incorrect queue information.

This PR updates queue-name parsing to strip the known prefix and suffix from the Redis key instead of relying on colon position.

## Changes

- Add shared Redis key parsing helper for provider queue discovery
- Fix BullMQ queue discovery for prefixes containing colons
- Fix Bull queue discovery for the same prefix format
- Add regression tests for colon-delimited prefixes

## Verification

```bash
pnpm --filter @bullstudio/queue test -- bullmq-provider.test.ts bull-provider.test.ts
pnpm --filter @bullstudio/queue lint
```

Both commands pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queue discovery to correctly handle prefixes containing colons (e.g., `tenant:bull`).

* **Tests**
  * Added test coverage for queue discovery and job counting with multi-part prefixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/emirce/bullstudio/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->