### PR TITLE
feat: Introduce global dashboard overview and flexible prefix discovery

### DIFF
--- a/apps/frontend/.env.example
+++ b/apps/frontend/.env.example
@@ -1,0 +1,12 @@
+# Copy to .env for local development. These configure the dev-only standalone
+# dashboard API (loaded into process.env by vite.config.ts).
+
+# Redis connection used to read queues.
+REDIS_URL=redis://localhost:6379
+
+# Queue prefixes to scan. Comma-separated. Each entry may be:
+#   - a literal prefix            e.g. bull
+#   - a glob pattern              e.g. local:{*}  (expands to every concrete
+#                                 local:{<module>} prefix found in Redis)
+#   - "*"                         auto-discover every prefix in the instance
+# REDIS_PREFIX=local:{*}

--- a/apps/frontend/src/components/Sidebar.tsx
+++ b/apps/frontend/src/components/Sidebar.tsx
@@ -15,7 +15,13 @@ import {
 import { cn } from "@bullstudio/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useLocation } from "@tanstack/react-router";
-import { Database, Github, LogOut, Twitter } from "lucide-react";
+import {
+  Database,
+  Github,
+  LayoutDashboard,
+  LogOut,
+  Twitter,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { JobDistributionPie } from "@/components/overview/JobDistributionPie";
 import { usePolling } from "@/components/PollingProvider";
@@ -35,6 +41,11 @@ interface AuthSessionResponse {
   authEnabled?: boolean;
 }
 
+/**
+ * Dashboard sidebar: an overview link plus the queue list, grouped by prefix
+ * when more than one is present, and a live Redis/queue-source connection
+ * indicator.
+ */
 export function AppSidebar() {
   const location = useLocation();
   const pathname = location.pathname;
@@ -55,9 +66,6 @@ export function AppSidebar() {
   const queueSource = connectionInfo?.queueSource
     ? getQueueSourceViewModel(connectionInfo.queueSource)
     : null;
-
-  const hasMultiplePrefixes =
-    queueSource?.prefixes && queueSource.prefixes.length > 1;
 
   // If the status query itself fails the API is unreachable; treat that as the
   // worst case so the indicator never shows a stale "connected" state.
@@ -88,6 +96,11 @@ export function AppSidebar() {
       queuesByPrefix.set(queue.prefix ?? "", [queue]);
     }
   }
+
+  // Group by prefix whenever more than one is present. Derived from the queue
+  // list itself (not queueSource.prefixes, which is empty in embedded mode) so
+  // prefix headers show in both standalone and embedded dashboards.
+  const hasMultiplePrefixes = queuesByPrefix.size > 1;
 
   const renderQueueItem = (queue: (typeof queueList)[number]) => {
     const routeParam = queueRouteParam(queue);
@@ -120,13 +133,10 @@ export function AppSidebar() {
   };
 
   return (
-    <Sidebar
-      collapsible="none"
-      className="sticky top-0 h-svh border-r-0"
-    >
+    <Sidebar collapsible="none" className="sticky top-0 h-svh border-r-0">
       {/* Header with Logo */}
       <SidebarHeader className="h-16 shrink-0 justify-center border-b border-sidebar-border px-4">
-        <div className="flex items-center gap-3">
+        <Link to="/" className="flex items-center gap-3">
           <img
             src={dashboardLogo?.src ?? getAssetUrl("/logo.svg")}
             alt={dashboardLogo?.alt ?? "bullstudio"}
@@ -140,10 +150,31 @@ export function AppSidebar() {
               {dashboardIdentity ? "Embedded" : "Standalone"}
             </span>
           </div>
-        </div>
+        </Link>
       </SidebarHeader>
 
       <SidebarContent>
+        {/* Aggregate overview across all queues */}
+        <SidebarGroup>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  isActive={pathname === "/"}
+                  tooltip="Overview"
+                  className="h-9"
+                >
+                  <Link to="/" className="h-9">
+                    <LayoutDashboard className="size-4" />
+                    <span className="text-sm">Overview</span>
+                  </Link>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+
         {hasMultiplePrefixes ? (
           Array.from(queuesByPrefix, ([prefix, prefixQueues]) => (
             <SidebarGroup key={prefix}>

--- a/apps/frontend/src/components/overview/QueueCard.tsx
+++ b/apps/frontend/src/components/overview/QueueCard.tsx
@@ -1,0 +1,57 @@
+import type { JobCounts } from "@bullstudio/connect-types";
+import { Badge } from "@bullstudio/ui/components/badge";
+import { Card } from "@bullstudio/ui/components/card";
+import { Link } from "@tanstack/react-router";
+import { QueueStatusBar } from "./QueueStatusBar";
+
+type QueueCardProps = {
+  name: string;
+  /** Prefix-qualified route param (see queueRouteParam). */
+  queueParam: string;
+  counts?: JobCounts;
+  isPaused?: boolean;
+};
+
+/**
+ * Compact card for a single queue on the overview grid: shows the queue name,
+ * a paused badge, and a status bar of its job distribution. Links to the
+ * queue's detail view.
+ *
+ * @param name - Queue name shown on the card.
+ * @param queueParam - Prefix-qualified route param used to link to the queue's detail view.
+ * @param counts - Per-status job counts; omitted while still loading.
+ * @param isPaused - Whether the queue is currently paused (renders a badge).
+ */
+export function QueueCard({
+  name,
+  queueParam,
+  counts,
+  isPaused,
+}: QueueCardProps) {
+  return (
+    <Link
+      to="/queues/$queueName"
+      params={{ queueName: queueParam }}
+      className="rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+    >
+      <Card className="h-full gap-3 p-4 transition-colors hover:border-ring/40 hover:bg-accent/40">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="truncate font-mono text-sm font-medium text-foreground">
+            {name}
+          </span>
+          {isPaused && (
+            <Badge variant="secondary" className="ml-auto">
+              Paused
+            </Badge>
+          )}
+        </div>
+
+        {counts ? (
+          <QueueStatusBar counts={counts} />
+        ) : (
+          <span className="text-xs text-muted-foreground">No data</span>
+        )}
+      </Card>
+    </Link>
+  );
+}

--- a/apps/frontend/src/components/overview/QueueStatusBar.tsx
+++ b/apps/frontend/src/components/overview/QueueStatusBar.tsx
@@ -1,0 +1,65 @@
+import type { JobCounts } from "@bullstudio/connect-types";
+import { cn } from "@bullstudio/ui/lib/utils";
+import { formatNumber } from "@bullstudio/ui/shared";
+
+type QueueStatusBarProps = {
+  counts: JobCounts;
+  className?: string;
+};
+
+// Same status palette as JobDistributionPie so the bar and the sidebar pie read
+// consistently. Order defines left-to-right fill order in the bar.
+const SEGMENTS = [
+  { key: "active", label: "Active", color: "#60a5fa" },
+  { key: "waiting", label: "Waiting", color: "#f59e0b" },
+  { key: "delayed", label: "Delayed", color: "#38bdf8" },
+  { key: "prioritized", label: "Prioritized", color: "#a78bfa" },
+  { key: "waitingChildren", label: "Waiting children", color: "#2dd4bf" },
+  { key: "paused", label: "Paused", color: "#a1a1aa" },
+  { key: "completed", label: "Completed", color: "#10b981" },
+  { key: "failed", label: "Failed", color: "#f87171" },
+] as const satisfies ReadonlyArray<{
+  key: keyof JobCounts;
+  label: string;
+  color: string;
+}>;
+
+/**
+ * Horizontal stacked bar that fills with one colored segment per non-empty job
+ * status, sized proportionally to its share of the total. Each segment shows
+ * its count and names its status on hover.
+ *
+ * @param counts - Per-status job counts driving the segment sizes.
+ * @param className - Optional extra classes applied to the wrapper.
+ */
+export function QueueStatusBar({ counts, className }: QueueStatusBarProps) {
+  const segments = SEGMENTS.map((segment) => ({
+    ...segment,
+    value: counts[segment.key],
+  })).filter((segment) => segment.value > 0);
+
+  const total = segments.reduce((sum, segment) => sum + segment.value, 0);
+
+  return (
+    <div className={cn("space-y-1.5", className)}>
+      <div className="flex h-4 w-full gap-px overflow-hidden rounded-full bg-muted text-[10px] font-medium leading-none text-white/95">
+        {segments.map((segment) => (
+          <div
+            key={segment.key}
+            className="flex min-w-min items-center justify-center"
+            style={{
+              width: `${(segment.value / total) * 100}%`,
+              backgroundColor: segment.color,
+            }}
+            title={`${segment.label}: ${segment.value}`}
+          >
+            <span className="truncate px-1">{formatNumber(segment.value)}</span>
+          </div>
+        ))}
+      </div>
+      <div className="text-xs text-muted-foreground">
+        {formatNumber(total)} {total === 1 ? "job" : "jobs"}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/overview/SlowestJobsTable.tsx
+++ b/apps/frontend/src/components/overview/SlowestJobsTable.tsx
@@ -17,26 +17,57 @@ import {
 import { formatDuration } from "@bullstudio/ui/shared";
 import { useNavigate } from "@tanstack/react-router";
 import { DEFAULT_JOBS_SEARCH } from "@/lib/jobs";
+import { queueRouteParam } from "@/lib/queue-key";
 
 type SlowJob = OverviewMetricsResponse["slowestJobs"][number];
 
 type SlowestJobsTableProps = {
   jobs: SlowJob[];
   /**
-   * Prefix-qualified route param for the queue these jobs belong to (the
-   * overview is scoped to a single queue), so clicking through disambiguates
-   * queues that share a name across prefixes.
+   * Prefix-qualified route param when the table is scoped to a single queue.
+   * Omit it on the global overview and pass `queues` instead so each row links
+   * to the queue the job actually belongs to.
    */
-  queueParam: string;
+  queueParam?: string;
+  /**
+   * Queue list used to resolve a row's destination by job `queueName` when the
+   * table spans multiple queues (global overview). Ignored when `queueParam`
+   * is provided.
+   */
+  queues?: ReadonlyArray<{ name: string; prefix?: string }>;
 };
 
-export function SlowestJobsTable({ jobs, queueParam }: SlowestJobsTableProps) {
+/**
+ * Table of the slowest jobs by processing time. Rows link to the originating
+ * queue's job view — scoped to a single queue via `queueParam`, or resolved
+ * per row from `queues` when rendered on the global overview.
+ *
+ * @param jobs - Slowest jobs to render, already sorted by processing time.
+ * @param queueParam - Fixed queue route param when the table is scoped to one queue.
+ * @param queues - Queue list used to resolve a row's queue by name in global (multi-queue) mode.
+ */
+export function SlowestJobsTable({
+  jobs,
+  queueParam,
+  queues,
+}: SlowestJobsTableProps) {
   const navigate = useNavigate();
 
+  // Single-queue mode uses the fixed param; global mode resolves per row from
+  // the job's queueName (jobs only carry the bare name, so the first matching
+  // prefix wins when names collide across prefixes).
+  const resolveQueueParam = (job: SlowJob): string | undefined => {
+    if (queueParam) return queueParam;
+    const match = queues?.find((queue) => queue.name === job.queueName);
+    return match ? queueRouteParam(match) : undefined;
+  };
+
   const handleJobClick = (job: SlowJob) => {
+    const targetParam = resolveQueueParam(job);
+    if (!targetParam) return;
     navigate({
       to: "/queues/$queueName/jobs",
-      params: { queueName: queueParam },
+      params: { queueName: targetParam },
       search: { ...DEFAULT_JOBS_SEARCH, selected: job.id },
     });
   };
@@ -62,34 +93,39 @@ export function SlowestJobsTable({ jobs, queueParam }: SlowestJobsTableProps) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {jobs.map((job) => (
-                <TableRow
-                  key={job.id}
-                  className="cursor-pointer hover:bg-muted/60"
-                  onClick={() => handleJobClick(job)}
-                >
-                  <TableCell>
-                    <div className="flex flex-col">
-                      <span className="font-medium text-foreground">
-                        {job.name}
+              {jobs.map((job) => {
+                const navigable = Boolean(resolveQueueParam(job));
+                return (
+                  <TableRow
+                    key={job.id}
+                    className={
+                      navigable ? "cursor-pointer hover:bg-muted/60" : undefined
+                    }
+                    onClick={navigable ? () => handleJobClick(job) : undefined}
+                  >
+                    <TableCell>
+                      <div className="flex flex-col">
+                        <span className="font-medium text-foreground">
+                          {job.name}
+                        </span>
+                        <span className="text-xs text-muted-foreground font-mono">
+                          {job.id}
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <span className="font-mono text-sm text-muted-foreground">
+                        {job.queueName}
                       </span>
-                      <span className="text-xs text-muted-foreground font-mono">
-                        {job.id}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <span className="font-mono text-sm text-amber-500">
+                        {formatDuration(job.processingTimeMs)}
                       </span>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <span className="font-mono text-sm text-muted-foreground">
-                      {job.queueName}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <span className="font-mono text-sm text-amber-500">
-                      {formatDuration(job.processingTimeMs)}
-                    </span>
-                  </TableCell>
-                </TableRow>
-              ))}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         )}

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import type { JobCounts } from "@bullstudio/connect-types";
 import { Button } from "@bullstudio/ui/components/button";
 import {
   Empty,
@@ -6,32 +7,97 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@bullstudio/ui/components/empty";
-import { useQuery } from "@tanstack/react-query";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@bullstudio/ui/components/select";
+import { Separator } from "@bullstudio/ui/components/separator";
+import { Skeleton } from "@bullstudio/ui/components/skeleton";
+import { useIsFetching, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { ExternalLink } from "lucide-react";
-import { useEffect } from "react";
+import { ExternalLink, RefreshCw } from "lucide-react";
+import { useState } from "react";
+import { FailingJobTypesTable } from "@/components/overview/FailingJobTypesTable";
+import { JobStateCards } from "@/components/overview/JobStateCards";
+import { MetricCardsGrid } from "@/components/overview/MetricCardsGrid";
+import { ProcessingTimeChart } from "@/components/overview/ProcessingTimeChart";
+import { QueueCard } from "@/components/overview/QueueCard";
+import { SlowestJobsTable } from "@/components/overview/SlowestJobsTable";
+import { ThroughputChart } from "@/components/overview/ThroughputChart";
+import { usePolling } from "@/components/PollingProvider";
 import { useTRPC } from "@/integrations/trpc/react";
 import { queueRouteParam } from "@/lib/queue-key";
+import { TIME_RANGES } from "@/lib/time-ranges";
 
 export const Route = createFileRoute("/")({ component: OverviewPage });
 
+const EMPTY_COUNTS: JobCounts = {
+  waiting: 0,
+  active: 0,
+  completed: 0,
+  failed: 0,
+  delayed: 0,
+  paused: 0,
+  prioritized: 0,
+  waitingChildren: 0,
+};
+
+const JOB_COUNT_KEYS = Object.keys(EMPTY_COUNTS) as (keyof JobCounts)[];
+
+const JOB_STATE_SKELETON_KEYS = [
+  "state-1",
+  "state-2",
+  "state-3",
+  "state-4",
+  "state-5",
+  "state-6",
+];
+
+const QUEUE_CARD_SKELETON_KEYS = [
+  "queue-1",
+  "queue-2",
+  "queue-3",
+  "queue-4",
+  "queue-5",
+  "queue-6",
+];
+
+const PERF_SKELETON_KEYS = ["perf-1", "perf-2", "perf-3", "perf-4"];
+
+/**
+ * Home dashboard aggregating every queue: a combined job-state snapshot, a grid
+ * of per-queue cards grouped by prefix, and global performance metrics over a
+ * selectable time range.
+ */
 function OverviewPage() {
   const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const { enabled: pollEnabled, interval: pollInterval } = usePolling();
+  const [timeRange, setTimeRange] = useState<number>(5 / 60);
 
-  const navigate = Route.useNavigate();
+  const isFetching = useIsFetching() > 0;
+  const refreshAll = () => queryClient.invalidateQueries();
 
-  const { data: queues } = useQuery(trpc.queues.list.queryOptions());
+  const { data: queues, isLoading: loadingQueues } = useQuery(
+    trpc.queues.list.queryOptions(undefined, {
+      refetchInterval: pollEnabled ? pollInterval : false,
+    }),
+  );
 
-  useEffect(() => {
-    if (queues && queues.length > 0) {
-      navigate({
-        to: "/queues/$queueName",
-        params: { queueName: queueRouteParam(queues[0]) },
-      });
-    }
-  }, [queues, navigate]);
+  // No queueName/prefix → the backend aggregates metrics across every queue.
+  const { data: metrics, isLoading: loadingMetrics } = useQuery(
+    trpc.overview.metrics.queryOptions(
+      { timeRangeHours: timeRange },
+      { refetchInterval: pollEnabled ? pollInterval : false },
+    ),
+  );
 
-  if (queues && !queues.length) {
+  const queueList = queues ?? [];
+
+  if (queues && queueList.length === 0) {
     return (
       <Empty>
         <EmptyHeader>
@@ -57,5 +123,188 @@ function OverviewPage() {
     );
   }
 
-  return null;
+  // Sum every queue's live counts into a single aggregate snapshot.
+  const aggregatedCounts = queueList.reduce<JobCounts>(
+    (acc, queue) => {
+      if (!queue.jobCounts) return acc;
+      for (const key of JOB_COUNT_KEYS) {
+        acc[key] += queue.jobCounts[key] ?? 0;
+      }
+      return acc;
+    },
+    { ...EMPTY_COUNTS },
+  );
+
+  // Bucket queues by prefix, preserving backend order. When more than one
+  // prefix exists each becomes its own labelled section (mirrors the sidebar).
+  const queuesByPrefix = new Map<string, typeof queueList>();
+  for (const queue of queueList) {
+    const bucket = queuesByPrefix.get(queue.prefix ?? "");
+    if (bucket) {
+      bucket.push(queue);
+    } else {
+      queuesByPrefix.set(queue.prefix ?? "", [queue]);
+    }
+  }
+  const hasMultiplePrefixes = queuesByPrefix.size > 1;
+
+  const renderQueueCard = (queue: (typeof queueList)[number]) => {
+    const routeParam = queueRouteParam(queue);
+    return (
+      <QueueCard
+        key={routeParam}
+        name={queue.name}
+        queueParam={routeParam}
+        counts={queue.jobCounts}
+        isPaused={queue.isPaused}
+      />
+    );
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      <header className="flex h-14 shrink-0 items-center gap-2">
+        <div className="flex flex-col">
+          <h1 className="text-lg font-semibold text-foreground">Overview</h1>
+          <span className="text-xs text-muted-foreground">
+            {queueList.length} {queueList.length === 1 ? "queue" : "queues"}
+          </span>
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={refreshAll}
+          disabled={isFetching}
+          className="ml-auto bg-card"
+        >
+          <RefreshCw
+            className={`size-4 mr-2 ${isFetching ? "animate-spin" : ""}`}
+          />
+          Refresh page
+        </Button>
+      </header>
+
+      <div className="space-y-6 pt-2">
+        {/* Live job-state snapshot aggregated across all queues. */}
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium text-muted-foreground">
+            Jobs distribution
+          </h2>
+          {loadingQueues ? (
+            <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+              {JOB_STATE_SKELETON_KEYS.map((key) => (
+                <Skeleton key={key} className="h-20 w-full bg-zinc-800/50" />
+              ))}
+            </div>
+          ) : (
+            <JobStateCards counts={aggregatedCounts} />
+          )}
+        </section>
+
+        <Separator />
+
+        {/* All queues at a glance. */}
+        <section className="space-y-3">
+          <h2 className="text-sm font-medium text-muted-foreground">Queues</h2>
+          {loadingQueues ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {QUEUE_CARD_SKELETON_KEYS.map((key) => (
+                <Skeleton key={key} className="h-32 w-full bg-zinc-800/50" />
+              ))}
+            </div>
+          ) : hasMultiplePrefixes ? (
+            <div className="space-y-6">
+              {Array.from(queuesByPrefix, ([prefix, prefixQueues]) => (
+                <div key={prefix} className="space-y-3">
+                  <h3 className="font-mono text-xs font-medium uppercase tracking-wide text-muted-foreground/80">
+                    {prefix}
+                  </h3>
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {prefixQueues.map(renderQueueCard)}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {queueList.map(renderQueueCard)}
+            </div>
+          )}
+        </section>
+
+        <Separator />
+
+        {/* Performance metrics aggregated across all queues. */}
+        <div className="flex w-full items-center justify-between gap-3">
+          <h2 className="text-sm font-medium text-muted-foreground">
+            Performance
+          </h2>
+          <Select
+            value={String(timeRange)}
+            onValueChange={(value) => setTimeRange(Number(value))}
+          >
+            <SelectTrigger className="w-[150px] bg-card">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TIME_RANGES.map((range) => (
+                <SelectItem key={range.value} value={range.value}>
+                  {range.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {loadingMetrics ? (
+          <PerformanceSkeleton />
+        ) : metrics ? (
+          <>
+            <section className="space-y-3">
+              <MetricCardsGrid
+                summary={metrics.summary}
+                timeSeries={metrics.timeSeries}
+                timeRange={timeRange}
+                nativeMetrics={metrics.nativeMetrics}
+              />
+            </section>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <ThroughputChart
+                data={metrics.timeSeries}
+                timeRange={timeRange}
+                nativeMetrics={metrics.nativeMetrics}
+              />
+              <ProcessingTimeChart
+                data={metrics.timeSeries}
+                timeRange={timeRange}
+              />
+            </div>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <SlowestJobsTable jobs={metrics.slowestJobs} queues={queueList} />
+              <FailingJobTypesTable jobTypes={metrics.failingJobTypes} />
+            </div>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+/** Loading placeholder for the performance section (metric cards + charts). */
+function PerformanceSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {PERF_SKELETON_KEYS.map((key) => (
+          <Skeleton key={key} className="h-32 w-full bg-zinc-800/50" />
+        ))}
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Skeleton className="h-80 w-full bg-zinc-800/50" />
+        <Skeleton className="h-80 w-full bg-zinc-800/50" />
+      </div>
+    </div>
+  );
 }

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -2,41 +2,52 @@ import tailwindcss from "@tailwindcss/vite";
 import { devtools } from "@tanstack/devtools-vite";
 import { tanstackRouter } from "@tanstack/router-plugin/vite";
 import viteReact from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, loadEnv } from "vite";
 import viteTsConfigPaths from "vite-tsconfig-paths";
 import { standaloneApiPlugin } from "./dev/standalone-api-plugin";
 
-const config = defineConfig({
-  build: {
-    outDir: "dist/client",
-  },
-  plugins: [
-    standaloneApiPlugin(),
-    devtools(),
-    viteTsConfigPaths({
-      projects: ["./tsconfig.json"],
-    }),
-    tailwindcss(),
-    tanstackRouter({
-      target: "react",
-    }),
-    viteReact(),
-  ],
-  resolve: {
-    dedupe: ["react", "react-dom"],
-  },
-  optimizeDeps: {
-    include: [
-      "react",
-      "react-dom",
-      "react/jsx-runtime",
-      "react/jsx-dev-runtime",
-    ],
-    esbuildOptions: {
-      // Handle CommonJS modules
-      format: "esm",
-    },
-  },
-});
+export default defineConfig(({ mode }) => {
+  // The dev-only standalone API (see standalone-api-plugin) reads connection
+  // config from process.env. Vite does not put non-VITE_ vars from .env into
+  // process.env on its own, so load every key here and fill in the gaps —
+  // real shell env vars still win, keeping CI/overrides authoritative.
+  const fileEnv = loadEnv(mode, process.cwd(), "");
+  for (const [key, value] of Object.entries(fileEnv)) {
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
 
-export default config;
+  return {
+    build: {
+      outDir: "dist/client",
+    },
+    plugins: [
+      standaloneApiPlugin(),
+      devtools(),
+      viteTsConfigPaths({
+        projects: ["./tsconfig.json"],
+      }),
+      tailwindcss(),
+      tanstackRouter({
+        target: "react",
+      }),
+      viteReact(),
+    ],
+    resolve: {
+      dedupe: ["react", "react-dom"],
+    },
+    optimizeDeps: {
+      include: [
+        "react",
+        "react-dom",
+        "react/jsx-runtime",
+        "react/jsx-dev-runtime",
+      ],
+      esbuildOptions: {
+        // Handle CommonJS modules
+        format: "esm",
+      },
+    },
+  };
+});

--- a/apps/standalone/src/queue/detection/prefix-discovery.test.ts
+++ b/apps/standalone/src/queue/detection/prefix-discovery.test.ts
@@ -5,7 +5,12 @@ import {
   ensureRedisAvailable,
   flushTestDb,
 } from "../test-utils/redis";
-import { discoverPrefixes } from "./prefix-discovery";
+import {
+  discoverPrefixes,
+  discoverPrefixesMatching,
+  prefixPatternToRegExp,
+  resolveConfiguredPrefixes,
+} from "./prefix-discovery";
 
 describe("discoverPrefixes", () => {
   let redis: Redis;
@@ -94,5 +99,115 @@ describe("discoverPrefixes", () => {
   it("skips a key whose first segment is empty", async () => {
     await redis.set(":garbage:meta", "1");
     expect(await discoverPrefixes(redis)).toEqual([]);
+  });
+});
+
+describe("prefixPatternToRegExp", () => {
+  it("extracts a hash-tagged prefix from a full key", () => {
+    const re = prefixPatternToRegExp("local:{*}");
+    expect("local:{event}:event--company.created:meta".match(re)?.[0]).toBe(
+      "local:{event}",
+    );
+  });
+
+  it("confines the wildcard to a single key segment", () => {
+    const re = prefixPatternToRegExp("local:*");
+    expect("local:my-queue:meta".match(re)?.[0]).toBe("local:my-queue");
+  });
+
+  it("does not match a key outside the pattern", () => {
+    const re = prefixPatternToRegExp("local:{*}");
+    expect(re.test("staging:{event}:q:meta")).toBe(false);
+  });
+});
+
+describe("discoverPrefixesMatching", () => {
+  let redis: Redis;
+
+  beforeAll(async () => {
+    await ensureRedisAvailable();
+    redis = createTestRedis();
+  });
+
+  afterAll(async () => {
+    if (!redis) return;
+    await redis.quit().catch(() => {});
+  });
+
+  beforeEach(async () => {
+    await flushTestDb(redis);
+  });
+
+  it("expands a hash-tag glob into the concrete prefixes present", async () => {
+    await redis.mset(
+      "local:{event}:q1:meta",
+      "1",
+      "local:{open-search}:q2:meta",
+      "1",
+      "local:{audit}:q3:id",
+      "1",
+    );
+    expect(await discoverPrefixesMatching(redis, "local:{*}")).toEqual([
+      "local:{audit}",
+      "local:{event}",
+      "local:{open-search}",
+    ]);
+  });
+
+  it("ignores prefixes that do not match the pattern", async () => {
+    await redis.set("local:{event}:q:meta", "1");
+    await redis.set("staging:{event}:q:meta", "1");
+    expect(await discoverPrefixesMatching(redis, "local:{*}")).toEqual([
+      "local:{event}",
+    ]);
+  });
+});
+
+describe("resolveConfiguredPrefixes", () => {
+  let redis: Redis;
+
+  beforeAll(async () => {
+    await ensureRedisAvailable();
+    redis = createTestRedis();
+  });
+
+  afterAll(async () => {
+    if (!redis) return;
+    await redis.quit().catch(() => {});
+  });
+
+  beforeEach(async () => {
+    await flushTestDb(redis);
+  });
+
+  it("falls back to the default prefix when nothing is configured", async () => {
+    expect(await resolveConfiguredPrefixes(redis, undefined, "bull")).toEqual([
+      "bull",
+    ]);
+  });
+
+  it("uses literal prefixes verbatim", async () => {
+    expect(
+      await resolveConfiguredPrefixes(redis, ["alpha", "beta"], "bull"),
+    ).toEqual(["alpha", "beta"]);
+  });
+
+  it("expands a glob pattern against Redis", async () => {
+    await redis.mset(
+      "local:{event}:q1:meta",
+      "1",
+      "local:{open-search}:q2:meta",
+      "1",
+    );
+    expect(
+      await resolveConfiguredPrefixes(redis, ["local:{*}"], "bull"),
+    ).toEqual(["local:{event}", "local:{open-search}"]);
+  });
+
+  it("merges literal and glob entries, de-duplicated and sorted", async () => {
+    await redis.set("local:{event}:q:meta", "1");
+    expect(
+      await resolveConfiguredPrefixes(redis, ["zeta", "local:{*}"], "bull"),
+    ).toEqual(["local:{event}", "zeta"]);
   });
 });

--- a/apps/standalone/src/queue/detection/prefix-discovery.test.ts
+++ b/apps/standalone/src/queue/detection/prefix-discovery.test.ts
@@ -43,6 +43,15 @@ describe("discoverPrefixes", () => {
     expect(await discoverPrefixes(redis)).toEqual(["bull"]);
   });
 
+  it("keeps a multi-segment prefix intact (hash tag / colon prefix)", async () => {
+    await redis.set("local:{event}:os-sync:meta", "1");
+    await redis.set("tenant:bull:email:id", "1");
+    expect(await discoverPrefixes(redis)).toEqual([
+      "local:{event}",
+      "tenant:bull",
+    ]);
+  });
+
   it("returns prefixes from both Bull and BullMQ key patterns merged and sorted", async () => {
     await redis.set("stage:q1:meta", "1");
     await redis.set("legacy:q1:id", "1");

--- a/apps/standalone/src/queue/detection/prefix-discovery.ts
+++ b/apps/standalone/src/queue/detection/prefix-discovery.ts
@@ -5,21 +5,122 @@ import type Redis from "ioredis";
  * by scanning for known key patterns:
  *   - BullMQ: `<prefix>:<queue>:meta`
  *   - Bull:   `<prefix>:<queue>:id`
+ *
+ * @param redis - Redis client to scan.
+ * @returns Every distinct prefix found, sorted alphabetically.
  */
 export async function discoverPrefixes(redis: Redis): Promise<string[]> {
   const prefixes = new Set<string>();
+  const firstSegment = (key: string) => key.split(":")[0] || null;
 
-  await scanForPattern(redis, "*:*:meta", prefixes);
-  await scanForPattern(redis, "*:*:id", prefixes);
+  await scanForPattern(redis, "*:*:meta", firstSegment, prefixes);
+  await scanForPattern(redis, "*:*:id", firstSegment, prefixes);
 
   return Array.from(prefixes).sort();
 }
 
+/**
+ * Resolve the prefixes configured via `REDIS_PREFIX` into the concrete prefixes
+ * to query. Each configured entry is treated as:
+ *   - `"*"`            → every prefix in the instance (full discovery)
+ *   - a glob pattern   → e.g. `local:{*}` expands to `local:{event}`,
+ *                        `local:{open-search}`, … (every concrete prefix the
+ *                        pattern matches). `*` matches within a key segment.
+ *   - a literal prefix → used verbatim.
+ *
+ * Falls back to `defaultPrefix` when nothing is configured or nothing matches.
+ *
+ * @param redis - Redis client used to expand `*` and glob patterns.
+ * @param configured - Configured prefix entries (literals, globs, or `"*"`); `undefined`/empty falls back.
+ * @param defaultPrefix - Prefix returned when nothing is configured or no pattern matches.
+ * @returns The concrete prefixes to query, de-duplicated and sorted.
+ */
+export async function resolveConfiguredPrefixes(
+  redis: Redis,
+  configured: string[] | undefined,
+  defaultPrefix: string,
+): Promise<string[]> {
+  if (!configured || configured.length === 0) {
+    return [defaultPrefix];
+  }
+
+  const resolved = new Set<string>();
+  for (const entry of configured) {
+    if (entry === "*") {
+      for (const prefix of await discoverPrefixes(redis)) {
+        resolved.add(prefix);
+      }
+    } else if (entry.includes("*")) {
+      for (const prefix of await discoverPrefixesMatching(redis, entry)) {
+        resolved.add(prefix);
+      }
+    } else {
+      resolved.add(entry);
+    }
+  }
+
+  if (resolved.size === 0) {
+    return [defaultPrefix];
+  }
+  return Array.from(resolved).sort();
+}
+
+/**
+ * Expand a glob prefix pattern (e.g. `local:{*}`) into the concrete prefixes
+ * present in Redis. Scans the `<pattern>:*:meta` / `<pattern>:*:id` key spaces
+ * — `{` and `}` are literal in Redis glob matching, only `*` is a wildcard —
+ * and derives each key's prefix from the pattern.
+ *
+ * @param redis - Redis client to scan.
+ * @param pattern - Glob prefix pattern, e.g. `local:{*}`.
+ * @returns The concrete prefixes matching the pattern, sorted alphabetically.
+ */
+export async function discoverPrefixesMatching(
+  redis: Redis,
+  pattern: string,
+): Promise<string[]> {
+  const prefixes = new Set<string>();
+  const matcher = prefixPatternToRegExp(pattern);
+  const extractPrefix = (key: string) => matcher.exec(key)?.[0] ?? null;
+
+  await scanForPattern(redis, `${pattern}:*:meta`, extractPrefix, prefixes);
+  await scanForPattern(redis, `${pattern}:*:id`, extractPrefix, prefixes);
+
+  return Array.from(prefixes).sort();
+}
+
+/**
+ * Build an anchored regex that matches the prefix portion of a key for a glob
+ * pattern. `*` becomes `[^:]*` (a wildcard confined to a single key segment),
+ * every other character is matched literally. e.g. `local:{*}` →
+ * `/^local:\{[^:]*\}/`, which extracts `local:{event}` from a full key.
+ *
+ * @param pattern - Glob prefix pattern (only `*` is treated as a wildcard).
+ * @returns A start-anchored regex whose match is the key's prefix.
+ */
+export function prefixPatternToRegExp(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\\\*/g, "[^:]*");
+  return new RegExp(`^${escaped}`);
+}
+
 const MAX_SCAN_ITERATIONS = 10_000;
 
+/**
+ * SCAN Redis for keys matching `pattern`, collecting each key's prefix (via
+ * `extractPrefix`) into `out`. Iterates the full cursor, bounded by
+ * MAX_SCAN_ITERATIONS as a runaway guard.
+ *
+ * @param redis - Redis client to scan.
+ * @param pattern - Redis glob MATCH pattern.
+ * @param extractPrefix - Maps a matched key to its prefix, or `null` to skip it.
+ * @param out - Set accumulating the discovered prefixes (mutated in place).
+ */
 async function scanForPattern(
   redis: Redis,
   pattern: string,
+  extractPrefix: (key: string) => string | null,
   out: Set<string>,
 ): Promise<void> {
   let cursor = "0";
@@ -34,7 +135,7 @@ async function scanForPattern(
     );
     cursor = next;
     for (const key of keys) {
-      const prefix = key.split(":")[0];
+      const prefix = extractPrefix(key);
       if (prefix) out.add(prefix);
     }
     iterations++;

--- a/apps/standalone/src/queue/detection/prefix-discovery.ts
+++ b/apps/standalone/src/queue/detection/prefix-discovery.ts
@@ -11,10 +11,18 @@ import type Redis from "ioredis";
  */
 export async function discoverPrefixes(redis: Redis): Promise<string[]> {
   const prefixes = new Set<string>();
-  const firstSegment = (key: string) => key.split(":")[0] || null;
+  // Strip the trailing `:<queue>:<suffix>` to recover the full prefix, which
+  // may itself contain colons (e.g. a Redis Cluster hash tag like
+  // `local:{event}` or a tenant prefix like `tenant:bull`). Assumes a
+  // single-segment queue name, matching the `*:*:meta` / `*:*:id` scan shape.
+  const prefixOf = (key: string) => {
+    const parts = key.split(":");
+    if (parts.length < 3) return null;
+    return parts.slice(0, -2).join(":") || null;
+  };
 
-  await scanForPattern(redis, "*:*:meta", firstSegment, prefixes);
-  await scanForPattern(redis, "*:*:id", firstSegment, prefixes);
+  await scanForPattern(redis, "*:*:meta", prefixOf, prefixes);
+  await scanForPattern(redis, "*:*:id", prefixOf, prefixes);
 
   return Array.from(prefixes).sort();
 }

--- a/apps/standalone/src/queue/providers/bull/bull-provider.ts
+++ b/apps/standalone/src/queue/providers/bull/bull-provider.ts
@@ -17,7 +17,7 @@ import type {
 } from "@bullstudio/connect-types";
 import Bull from "bull";
 import Redis from "ioredis";
-import { discoverPrefixes } from "../../detection/prefix-discovery";
+import { resolveConfiguredPrefixes } from "../../detection/prefix-discovery";
 import { NotConnectedError } from "../../errors";
 import type {
   QueueProviderCapabilities,
@@ -69,21 +69,31 @@ export class BullProvider implements QueueService {
     return DEFAULT_PREFIX;
   }
 
+  /**
+   * Resolve (and memoize) the prefixes to scan from the configured ones,
+   * expanding `*` (all prefixes) and glob patterns like `local:{*}` against
+   * Redis. Falls back to the default prefix when none are configured.
+   *
+   * @returns The concrete prefixes to scan for this provider.
+   */
   private async getActivePrefixes(): Promise<string[]> {
     if (this.resolvedPrefixes) {
       return this.resolvedPrefixes;
     }
-    const explicit = this.config.prefixes;
-    if (explicit && explicit.length > 0 && !explicit.includes("*")) {
-      this.resolvedPrefixes = explicit;
-      return explicit;
+    const configured = this.config.prefixes;
+    const hasPattern = configured?.some((p) => p.includes("*")) ?? false;
+    if (hasPattern && this.connection) {
+      // Expand "*" (all prefixes) and globs like "local:{*}" against Redis.
+      this.resolvedPrefixes = await resolveConfiguredPrefixes(
+        this.connection,
+        configured,
+        this.defaultPrefix,
+      );
+    } else if (configured && configured.length > 0 && !hasPattern) {
+      this.resolvedPrefixes = configured;
+    } else {
+      this.resolvedPrefixes = [this.defaultPrefix];
     }
-    if (explicit?.includes("*") && this.connection) {
-      const found = await discoverPrefixes(this.connection);
-      this.resolvedPrefixes = found.length > 0 ? found : [this.defaultPrefix];
-      return this.resolvedPrefixes;
-    }
-    this.resolvedPrefixes = [this.defaultPrefix];
     return this.resolvedPrefixes;
   }
 

--- a/apps/standalone/src/queue/providers/bull/bull-provider.ts
+++ b/apps/standalone/src/queue/providers/bull/bull-provider.ts
@@ -179,6 +179,9 @@ export class BullProvider implements QueueService {
       if (this._isReconnecting) {
         this._isReconnecting = false;
         this._isConnected = true;
+        // Re-resolve prefixes after a reconnect: new queues/prefixes may have
+        // appeared while disconnected.
+        this.resolvedPrefixes = null;
         this.eventCallbacks.onReconnected?.();
       }
     });
@@ -198,6 +201,8 @@ export class BullProvider implements QueueService {
     }
 
     this._isConnected = false;
+    // Drop memoized prefixes so a fresh connection re-resolves them.
+    this.resolvedPrefixes = null;
   }
 
   isConnected(): boolean {

--- a/apps/standalone/src/queue/providers/bullmq/bullmq-provider.test.ts
+++ b/apps/standalone/src/queue/providers/bullmq/bullmq-provider.test.ts
@@ -64,16 +64,24 @@ describe("BullMqProvider (multi-prefix)", () => {
   });
 
   it("discovers queues when the configured prefix contains colons", async () => {
-    await track(await seedBullMqQueue({ prefix: "tenant:bull", name: "email" }));
+    await track(
+      await seedBullMqQueue({ prefix: "tenant:bull", name: "email" }),
+    );
 
-    await withBullMqProvider({ prefixes: ["tenant:bull"] }, async (provider) => {
-      const queues = await provider.getQueues();
-      expect(queues).toHaveLength(1);
-      expect(queues[0]).toMatchObject({ name: "email", prefix: "tenant:bull" });
+    await withBullMqProvider(
+      { prefixes: ["tenant:bull"] },
+      async (provider) => {
+        const queues = await provider.getQueues();
+        expect(queues).toHaveLength(1);
+        expect(queues[0]).toMatchObject({
+          name: "email",
+          prefix: "tenant:bull",
+        });
 
-      const counts = await provider.getJobCounts("email", "tenant:bull");
-      expect(counts.waiting).toBe(3);
-    });
+        const counts = await provider.getJobCounts("email", "tenant:bull");
+        expect(counts.waiting).toBe(3);
+      },
+    );
   });
 
   it("returns queues across multiple explicit prefixes with correct prefix fields", async () => {

--- a/apps/standalone/src/queue/providers/bullmq/bullmq-provider.ts
+++ b/apps/standalone/src/queue/providers/bullmq/bullmq-provider.ts
@@ -17,7 +17,7 @@ import type {
 } from "@bullstudio/connect-types";
 import { Queue } from "bullmq";
 import Redis from "ioredis";
-import { discoverPrefixes } from "../../detection/prefix-discovery";
+import { resolveConfiguredPrefixes } from "../../detection/prefix-discovery";
 import { NotConnectedError } from "../../errors";
 import type {
   QueueProviderCapabilities,
@@ -69,21 +69,31 @@ export class BullMqProvider implements QueueService {
     return DEFAULT_PREFIX;
   }
 
+  /**
+   * Resolve (and memoize) the prefixes to scan from the configured ones,
+   * expanding `*` (all prefixes) and glob patterns like `local:{*}` against
+   * Redis. Falls back to the default prefix when none are configured.
+   *
+   * @returns The concrete prefixes to scan for this provider.
+   */
   private async getActivePrefixes(): Promise<string[]> {
     if (this.resolvedPrefixes) {
       return this.resolvedPrefixes;
     }
-    const explicit = this.config.prefixes;
-    if (explicit && explicit.length > 0 && !explicit.includes("*")) {
-      this.resolvedPrefixes = explicit;
-      return explicit;
+    const configured = this.config.prefixes;
+    const hasPattern = configured?.some((p) => p.includes("*")) ?? false;
+    if (hasPattern && this.connection) {
+      // Expand "*" (all prefixes) and globs like "local:{*}" against Redis.
+      this.resolvedPrefixes = await resolveConfiguredPrefixes(
+        this.connection,
+        configured,
+        this.defaultPrefix,
+      );
+    } else if (configured && configured.length > 0 && !hasPattern) {
+      this.resolvedPrefixes = configured;
+    } else {
+      this.resolvedPrefixes = [this.defaultPrefix];
     }
-    if (explicit?.includes("*") && this.connection) {
-      const found = await discoverPrefixes(this.connection);
-      this.resolvedPrefixes = found.length > 0 ? found : [this.defaultPrefix];
-      return this.resolvedPrefixes;
-    }
-    this.resolvedPrefixes = [this.defaultPrefix];
     return this.resolvedPrefixes;
   }
 

--- a/apps/standalone/src/queue/providers/bullmq/bullmq-provider.ts
+++ b/apps/standalone/src/queue/providers/bullmq/bullmq-provider.ts
@@ -179,6 +179,9 @@ export class BullMqProvider implements QueueService {
       if (this._isReconnecting) {
         this._isReconnecting = false;
         this._isConnected = true;
+        // Re-resolve prefixes after a reconnect: new queues/prefixes may have
+        // appeared while disconnected.
+        this.resolvedPrefixes = null;
         this.eventCallbacks.onReconnected?.();
       }
     });
@@ -198,6 +201,8 @@ export class BullMqProvider implements QueueService {
     }
 
     this._isConnected = false;
+    // Drop memoized prefixes so a fresh connection re-resolves them.
+    this.resolvedPrefixes = null;
   }
 
   isConnected(): boolean {


### PR DESCRIPTION
This commit adds a new global overview page to the dashboard, providing an
aggregated view of all configured queues. It displays system health, job
distribution, and performance metrics across the entire Redis instance.

To enable this, and to offer greater flexibility for various Redis
deployments, the backend's queue prefix discovery mechanism has been
significantly enhanced:
*   The `REDIS_PREFIX` environment variable now supports literal prefixes,
    a `*` wildcard for full auto-discovery, and glob patterns (e.g.,
    `environment:{*}`) that dynamically resolve to concrete prefixes found in Redis.
*   This allows the dashboard to adapt seamlessly to different key naming
    conventions, including those using Redis Cluster hash tags.

The frontend now features dedicated components for aggregated job states,
individual queue cards with status bars, and global performance charts,
along with an improved `SlowestJobsTable` that can span multiple queues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Overview dashboard on `/` with queue cards, job distribution visuals, performance metrics, and loading skeletons
  * Always-available “Overview” item in the sidebar (links to `/`)
  * Time-range selector for performance charts
* **Improvements**
  * Queue cards now show queued state badges (e.g., Paused) and “No data” messaging
  * Manual “Refresh page” to invalidate cached data and reload the dashboard
  * Improved multi-prefix grouping and safer in-table navigation for slowest jobs
* **Bug Fixes**
  * Prevented automatic redirection from `/` to the first available queue
* **Documentation**
  * Updated frontend local-development Redis environment variable examples
<!-- end of auto-generated comment: release notes by coderabbit.ai -->