### PR TITLE
Add queue search by name and prefix

### DIFF
--- a/apps/frontend/src/components/QueueSearchProvider.tsx
+++ b/apps/frontend/src/components/QueueSearchProvider.tsx
@@ -1,0 +1,41 @@
+import { createContext, useContext, useMemo, useState } from "react";
+
+interface QueueSearchState {
+  /** Current queue search term, shared between the sidebar and the overview. */
+  query: string;
+  setQuery: (query: string) => void;
+}
+
+const QueueSearchContext = createContext<QueueSearchState | undefined>(
+  undefined,
+);
+
+/**
+ * Provides the shared queue-search term. The search input lives in the sidebar
+ * but the overview reads the same term, so both filter against one source.
+ *
+ * @param children - Subtree that can read/update the search term.
+ */
+export function QueueSearchProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const [query, setQuery] = useState("");
+  const value = useMemo(() => ({ query, setQuery }), [query]);
+
+  return (
+    <QueueSearchContext.Provider value={value}>
+      {children}
+    </QueueSearchContext.Provider>
+  );
+}
+
+/** Access the shared queue-search term. Must be used within QueueSearchProvider. */
+export const useQueueSearch = () => {
+  const context = useContext(QueueSearchContext);
+  if (context === undefined) {
+    throw new Error("useQueueSearch must be used within a QueueSearchProvider");
+  }
+  return context;
+};

--- a/apps/frontend/src/components/Sidebar.tsx
+++ b/apps/frontend/src/components/Sidebar.tsx
@@ -16,15 +16,7 @@ import {
 import { cn } from "@bullstudio/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useLocation } from "@tanstack/react-router";
-import {
-  Database,
-  Github,
-  LayoutDashboard,
-  LogOut,
-  Search,
-  Twitter,
-  X,
-} from "lucide-react";
+import { Database, LayoutDashboard, LogOut, Search, X } from "lucide-react";
 import { useEffect, useState } from "react";
 import { JobDistributionPie } from "@/components/overview/JobDistributionPie";
 import { usePolling } from "@/components/PollingProvider";

--- a/apps/frontend/src/components/Sidebar.tsx
+++ b/apps/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Input } from "@bullstudio/ui/components/input";
 import {
   Sidebar,
   SidebarContent,
@@ -15,14 +16,24 @@ import {
 import { cn } from "@bullstudio/ui/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { Link, useLocation } from "@tanstack/react-router";
-import { Database, LayoutDashboard, LogOut } from "lucide-react";
+import {
+  Database,
+  Github,
+  LayoutDashboard,
+  LogOut,
+  Search,
+  Twitter,
+  X,
+} from "lucide-react";
 import { useEffect, useState } from "react";
 import { JobDistributionPie } from "@/components/overview/JobDistributionPie";
 import { usePolling } from "@/components/PollingProvider";
+import { useQueueSearch } from "@/components/QueueSearchProvider";
 import { SettingsDialog } from "@/components/SettingsDialog";
 import { VERSION } from "@/const";
 import { useTRPC } from "@/integrations/trpc/react";
 import { queueRouteParam } from "@/lib/queue-key";
+import { queueMatchesQuery } from "@/lib/queue-search";
 import { getQueueSourceViewModel } from "@/lib/queue-source-status";
 import {
   getAssetUrl,
@@ -92,6 +103,16 @@ export function AppSidebar() {
   const dashboardLogo = dashboardIdentity?.logo;
   const dashboardTitle = dashboardIdentity?.title ?? "bullstudio";
   const { enabled: pollEnabled, interval: pollInterval } = usePolling();
+  const { query, setQuery } = useQueueSearch();
+  const [searchOpen, setSearchOpen] = useState(false);
+
+  const toggleSearch = () => {
+    setSearchOpen((open) => {
+      // Closing the search clears the active filter.
+      if (open) setQuery("");
+      return !open;
+    });
+  };
 
   const { data: connectionInfo, isError: connectionError } = useQuery(
     // Poll so the connection indicator reflects Redis going down/recovering
@@ -121,12 +142,15 @@ export function AppSidebar() {
   const queues = useQuery(trpc.queues.list.queryOptions());
 
   const queueList = queues.data ?? [];
+  const filteredQueues = queueList.filter((queue) =>
+    queueMatchesQuery(queue, query),
+  );
 
   // Bucket queues by prefix so each Redis prefix can render as its own labelled
   // subsection. Insertion order is preserved (the backend already returns
   // queues grouped by prefix), and queue names are unique within a prefix.
-  const queuesByPrefix = new Map<string, typeof queueList>();
-  for (const queue of queueList) {
+  const queuesByPrefix = new Map<string, typeof filteredQueues>();
+  for (const queue of filteredQueues) {
     const bucket = queuesByPrefix.get(queue.prefix ?? "");
     if (bucket) {
       bucket.push(queue);
@@ -174,24 +198,61 @@ export function AppSidebar() {
     <Sidebar collapsible="none" className="sticky top-0 h-svh border-r-0">
       {/* Header with Logo */}
       <SidebarHeader className="h-16 shrink-0 justify-center border-b border-sidebar-border px-4">
-        <Link to="/" className="flex items-center gap-3">
-          <img
-            src={dashboardLogo?.src ?? getAssetUrl("/logo.svg")}
-            alt={dashboardLogo?.alt ?? "bullstudio"}
-            className="size-8 shrink-0"
-          />
-          <div className="flex flex-col group-data-[collapsible=icon]:hidden">
-            <span className="font-semibold text-sm text-sidebar-foreground">
-              {dashboardTitle}
-            </span>
-            <span className="text-[10px] text-sidebar-foreground/55 uppercase tracking-wider">
-              {dashboardIdentity ? "Embedded" : "Standalone"}
-            </span>
-          </div>
-        </Link>
+        <div className="flex items-center justify-between gap-2">
+          <Link to="/" className="flex min-w-0 items-center gap-3">
+            <img
+              src={dashboardLogo?.src ?? getAssetUrl("/logo.svg")}
+              alt={dashboardLogo?.alt ?? "bullstudio"}
+              className="size-8 shrink-0"
+            />
+            <div className="flex min-w-0 flex-col group-data-[collapsible=icon]:hidden">
+              <span className="truncate font-semibold text-sm text-sidebar-foreground">
+                {dashboardTitle}
+              </span>
+              <span className="text-[10px] text-sidebar-foreground/55 uppercase tracking-wider">
+                {dashboardIdentity ? "Embedded" : "Standalone"}
+              </span>
+            </div>
+          </Link>
+          <button
+            type="button"
+            onClick={toggleSearch}
+            aria-label="Search queues"
+            aria-pressed={searchOpen}
+            className={cn(
+              "flex size-7 shrink-0 items-center justify-center rounded-md text-sidebar-foreground/60 transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring/50 group-data-[collapsible=icon]:hidden",
+              searchOpen && "bg-sidebar-accent text-sidebar-accent-foreground",
+            )}
+          >
+            <Search className="size-4" />
+          </button>
+        </div>
       </SidebarHeader>
 
       <SidebarContent>
+        {searchOpen && (
+          <div className="px-2 pt-2 group-data-[collapsible=icon]:hidden">
+            <div className="relative">
+              <Input
+                autoFocus
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Filter queues…"
+                className="h-9 bg-card pr-8 font-mono text-sm"
+              />
+              {query && (
+                <button
+                  type="button"
+                  onClick={() => setQuery("")}
+                  aria-label="Clear search"
+                  className="absolute right-2 top-1/2 flex size-5 -translate-y-1/2 items-center justify-center rounded text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  <X className="size-3.5" />
+                </button>
+              )}
+            </div>
+          </div>
+        )}
         {/* Aggregate overview across all queues */}
         <SidebarGroup>
           <SidebarGroupContent>
@@ -213,7 +274,11 @@ export function AppSidebar() {
           </SidebarGroupContent>
         </SidebarGroup>
 
-        {hasMultiplePrefixes ? (
+        {query.trim() && filteredQueues.length === 0 ? (
+          <div className="px-4 py-3 text-xs text-sidebar-foreground/55 group-data-[collapsible=icon]:hidden">
+            No queues match “{query.trim()}”.
+          </div>
+        ) : hasMultiplePrefixes ? (
           Array.from(queuesByPrefix, ([prefix, prefixQueues]) => (
             <SidebarGroup key={prefix}>
               <SidebarGroupLabel className="font-mono">
@@ -228,7 +293,7 @@ export function AppSidebar() {
           <SidebarGroup>
             <SidebarGroupLabel>Queues</SidebarGroupLabel>
             <SidebarGroupContent>
-              <SidebarMenu>{queueList.map(renderQueueItem)}</SidebarMenu>
+              <SidebarMenu>{filteredQueues.map(renderQueueItem)}</SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
         )}

--- a/apps/frontend/src/lib/queue-search.ts
+++ b/apps/frontend/src/lib/queue-search.ts
@@ -1,0 +1,21 @@
+export type SearchableQueue = { name: string; prefix?: string };
+
+/**
+ * Case-insensitive substring match of `query` against a queue's name or prefix.
+ * An empty/whitespace query matches everything (no filter applied).
+ *
+ * @param queue - Queue to test (its `name` and optional `prefix`).
+ * @param query - Raw search term as typed by the user.
+ * @returns Whether the queue should be shown for this query.
+ */
+export function queueMatchesQuery(
+  queue: SearchableQueue,
+  query: string,
+): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  return (
+    queue.name.toLowerCase().includes(q) ||
+    (queue.prefix?.toLowerCase().includes(q) ?? false)
+  );
+}

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import appCss from "../styles.css?url";
 
 import "../styles.css";
 import { PollingProvider } from "@/components/PollingProvider";
+import { QueueSearchProvider } from "@/components/QueueSearchProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
 
 interface MyRouterContext {
@@ -75,14 +76,16 @@ function RootDocument({ children }: { children: React.ReactNode }) {
           {isLogin ? (
             children
           ) : (
-            <SidebarProvider>
-              <AppSidebar />
-              <SidebarInset className="h-svh overflow-hidden">
-                <main className="flex flex-1 flex-col overflow-y-auto p-6">
-                  {children}
-                </main>
-              </SidebarInset>
-            </SidebarProvider>
+            <QueueSearchProvider>
+              <SidebarProvider>
+                <AppSidebar />
+                <SidebarInset className="h-svh overflow-hidden">
+                  <main className="flex flex-1 flex-col overflow-y-auto p-6">
+                    {children}
+                  </main>
+                </SidebarInset>
+              </SidebarProvider>
+            </QueueSearchProvider>
           )}
           <Toaster theme="dark" position="bottom-right" richColors />
         </PollingProvider>

--- a/apps/frontend/src/routes/__root.tsx
+++ b/apps/frontend/src/routes/__root.tsx
@@ -64,6 +64,12 @@ function RootComponent() {
   );
 }
 
+/**
+ * App shell: theme, polling, and queue-search providers wrap the sidebar and
+ * the routed content. The login route renders bare, without the shell.
+ *
+ * @param children - Routed page content rendered inside the shell.
+ */
 function RootDocument({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const isLogin = location.pathname === "/login";

--- a/apps/frontend/src/routes/index.tsx
+++ b/apps/frontend/src/routes/index.tsx
@@ -28,8 +28,10 @@ import { QueueCard } from "@/components/overview/QueueCard";
 import { SlowestJobsTable } from "@/components/overview/SlowestJobsTable";
 import { ThroughputChart } from "@/components/overview/ThroughputChart";
 import { usePolling } from "@/components/PollingProvider";
+import { useQueueSearch } from "@/components/QueueSearchProvider";
 import { useTRPC } from "@/integrations/trpc/react";
 import { queueRouteParam } from "@/lib/queue-key";
+import { queueMatchesQuery } from "@/lib/queue-search";
 import { TIME_RANGES } from "@/lib/time-ranges";
 
 export const Route = createFileRoute("/")({ component: OverviewPage });
@@ -76,6 +78,7 @@ function OverviewPage() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const { enabled: pollEnabled, interval: pollInterval } = usePolling();
+  const { query } = useQueueSearch();
   const [timeRange, setTimeRange] = useState<number>(5 / 60);
 
   const isFetching = useIsFetching() > 0;
@@ -135,10 +138,17 @@ function OverviewPage() {
     { ...EMPTY_COUNTS },
   );
 
+  // The queue grid honors the shared search term (name or prefix); the
+  // aggregate snapshot and performance metrics above stay global.
+  const filteredQueues = queueList.filter((queue) =>
+    queueMatchesQuery(queue, query),
+  );
+  const noMatches = query.trim().length > 0 && filteredQueues.length === 0;
+
   // Bucket queues by prefix, preserving backend order. When more than one
   // prefix exists each becomes its own labelled section (mirrors the sidebar).
-  const queuesByPrefix = new Map<string, typeof queueList>();
-  for (const queue of queueList) {
+  const queuesByPrefix = new Map<string, typeof filteredQueues>();
+  for (const queue of filteredQueues) {
     const bucket = queuesByPrefix.get(queue.prefix ?? "");
     if (bucket) {
       bucket.push(queue);
@@ -162,7 +172,7 @@ function OverviewPage() {
   };
 
   return (
-    <div className="flex h-full flex-col">
+    <div className="flex flex-col">
       <header className="flex h-14 shrink-0 items-center gap-2">
         <div className="flex flex-col">
           <h1 className="text-lg font-semibold text-foreground">Overview</h1>
@@ -212,6 +222,10 @@ function OverviewPage() {
                 <Skeleton key={key} className="h-32 w-full bg-zinc-800/50" />
               ))}
             </div>
+          ) : noMatches ? (
+            <p className="py-4 text-sm text-muted-foreground">
+              No queues match “{query.trim()}”.
+            </p>
           ) : hasMultiplePrefixes ? (
             <div className="space-y-6">
               {Array.from(queuesByPrefix, ([prefix, prefixQueues]) => (
@@ -227,7 +241,7 @@ function OverviewPage() {
             </div>
           ) : (
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-              {queueList.map(renderQueueCard)}
+              {filteredQueues.map(renderQueueCard)}
             </div>
           )}
         </section>


### PR DESCRIPTION
Summary

  Adds a search box to filter queues by name or prefix, shared between the sidebar and the overview. Useful when an instance has many queues across multiple prefixes.

  What's new

  - A magnifying-glass toggle sits next to the sidebar title. Clicking it opens an inline search field (below the title, above the Overview link) and marks the icon as active; clicking it again closes the field and clears the filter.
  - The field has a clear (✕) button to reset the term without closing.
  - Matching is case-insensitive against a queue's name or prefix — e.g. event matches both event--* queues and the local:{event} prefix.
  - The term lives in a shared QueueSearchProvider context:
    - it always filters the sidebar list (empty prefix groups are hidden);
    - it also filters the overview cards when on the overview, with an empty state when nothing matches;
    - inside a single queue, only the sidebar is affected.
  - The aggregate job-state snapshot and performance metrics stay global (intentionally not filtered).

  Also included

  - Layout fix: the overview content no longer sticks to the bottom of the viewport (dropped the h-full wrapper so the main scroll padding applies).
  - Removed now-unused Github/Twitter lucide imports in the sidebar.

  Implementation

  - New QueueSearchProvider (context) wired in __root, plus a shared queueMatchesQuery helper so the sidebar and overview filter from one source.
  - No backend changes — filtering is purely client-side on the already-loaded queue list.

  Files: lib/queue-search.ts, components/QueueSearchProvider.tsx (new); routes/__root.tsx, components/Sidebar.tsx, routes/index.tsx (modified).

  Testing

  - turbo typecheck (frontend) ✅
  - biome check ✅
  - Manually verified against a local Redis with multiple prefixes: filtering by name and by prefix, clear button, toggle open/close, empty states, and that single-queue pages only filter the sidebar.