### PR TITLE
feat: support Redis Cluster in standalone mode

### DIFF
--- a/.changeset/redis-cluster-standalone.md
+++ b/.changeset/redis-cluster-standalone.md
@@ -1,0 +1,5 @@
+---
+"bullstudio": minor
+---
+
+Standalone mode now supports Redis Cluster. Cluster mode is detected automatically from the target Redis (`INFO cluster`), the connection is established with a cluster client seeded from `REDIS_URL`, and prefix/queue discovery SCANs fan out across every master node — each node only returns keys for its own slots, so hash-tag prefixes like `{myapp}` are now discovered across the whole keyspace. Fixes the empty dashboard when pointing Bullstudio at a Redis Cluster (#8).

--- a/apps/standalone/src/queue/detection/prefix-discovery.ts
+++ b/apps/standalone/src/queue/detection/prefix-discovery.ts
@@ -1,4 +1,4 @@
-import type Redis from "ioredis";
+import { type RedisConnection, scanMatching } from "../utils";
 
 /**
  * Discover all Bull/BullMQ prefixes in a Redis instance
@@ -6,10 +6,12 @@ import type Redis from "ioredis";
  *   - BullMQ: `<prefix>:<queue>:meta`
  *   - Bull:   `<prefix>:<queue>:id`
  *
- * @param redis - Redis client to scan.
+ * @param redis - Redis client to scan (fans out across cluster masters).
  * @returns Every distinct prefix found, sorted alphabetically.
  */
-export async function discoverPrefixes(redis: Redis): Promise<string[]> {
+export async function discoverPrefixes(
+  redis: RedisConnection,
+): Promise<string[]> {
   const prefixes = new Set<string>();
   // Strip the trailing `:<queue>:<suffix>` to recover the full prefix, which
   // may itself contain colons (e.g. a Redis Cluster hash tag like
@@ -21,8 +23,8 @@ export async function discoverPrefixes(redis: Redis): Promise<string[]> {
     return parts.slice(0, -2).join(":") || null;
   };
 
-  await scanForPattern(redis, "*:*:meta", prefixOf, prefixes);
-  await scanForPattern(redis, "*:*:id", prefixOf, prefixes);
+  await collectPrefixes(redis, "*:*:meta", prefixOf, prefixes);
+  await collectPrefixes(redis, "*:*:id", prefixOf, prefixes);
 
   return Array.from(prefixes).sort();
 }
@@ -44,7 +46,7 @@ export async function discoverPrefixes(redis: Redis): Promise<string[]> {
  * @returns The concrete prefixes to query, de-duplicated and sorted.
  */
 export async function resolveConfiguredPrefixes(
-  redis: Redis,
+  redis: RedisConnection,
   configured: string[] | undefined,
   defaultPrefix: string,
 ): Promise<string[]> {
@@ -79,20 +81,20 @@ export async function resolveConfiguredPrefixes(
  * — `{` and `}` are literal in Redis glob matching, only `*` is a wildcard —
  * and derives each key's prefix from the pattern.
  *
- * @param redis - Redis client to scan.
+ * @param redis - Redis client to scan (fans out across cluster masters).
  * @param pattern - Glob prefix pattern, e.g. `local:{*}`.
  * @returns The concrete prefixes matching the pattern, sorted alphabetically.
  */
 export async function discoverPrefixesMatching(
-  redis: Redis,
+  redis: RedisConnection,
   pattern: string,
 ): Promise<string[]> {
   const prefixes = new Set<string>();
   const matcher = prefixPatternToRegExp(pattern);
   const extractPrefix = (key: string) => matcher.exec(key)?.[0] ?? null;
 
-  await scanForPattern(redis, `${pattern}:*:meta`, extractPrefix, prefixes);
-  await scanForPattern(redis, `${pattern}:*:id`, extractPrefix, prefixes);
+  await collectPrefixes(redis, `${pattern}:*:meta`, extractPrefix, prefixes);
+  await collectPrefixes(redis, `${pattern}:*:id`, extractPrefix, prefixes);
 
   return Array.from(prefixes).sort();
 }
@@ -113,46 +115,23 @@ export function prefixPatternToRegExp(pattern: string): RegExp {
   return new RegExp(`^${escaped}`);
 }
 
-const MAX_SCAN_ITERATIONS = 10_000;
-
 /**
- * SCAN Redis for keys matching `pattern`, collecting each key's prefix (via
- * `extractPrefix`) into `out`. Iterates the full cursor, bounded by
- * MAX_SCAN_ITERATIONS as a runaway guard.
+ * SCAN for keys matching `pattern`, collecting each key's prefix (via
+ * `extractPrefix`) into `out`.
  *
- * @param redis - Redis client to scan.
+ * @param redis - Redis client to scan (fans out across cluster masters).
  * @param pattern - Redis glob MATCH pattern.
  * @param extractPrefix - Maps a matched key to its prefix, or `null` to skip it.
  * @param out - Set accumulating the discovered prefixes (mutated in place).
  */
-async function scanForPattern(
-  redis: Redis,
+async function collectPrefixes(
+  redis: RedisConnection,
   pattern: string,
   extractPrefix: (key: string) => string | null,
   out: Set<string>,
 ): Promise<void> {
-  let cursor = "0";
-  let iterations = 0;
-  do {
-    const [next, keys] = await redis.scan(
-      cursor,
-      "MATCH",
-      pattern,
-      "COUNT",
-      200,
-    );
-    cursor = next;
-    for (const key of keys) {
-      const prefix = extractPrefix(key);
-      if (prefix) out.add(prefix);
-    }
-    iterations++;
-    if (iterations >= MAX_SCAN_ITERATIONS) {
-      console.warn(
-        `[PrefixDiscovery] Stopped after ` +
-          `${MAX_SCAN_ITERATIONS} iterations`,
-      );
-      break;
-    }
-  } while (cursor !== "0");
+  await scanMatching(redis, pattern, (key) => {
+    const prefix = extractPrefix(key);
+    if (prefix) out.add(prefix);
+  });
 }

--- a/apps/standalone/src/queue/detection/provider-detector.ts
+++ b/apps/standalone/src/queue/detection/provider-detector.ts
@@ -1,5 +1,5 @@
-import type Redis from "ioredis";
 import type { QueueProviderType } from "../types";
+import { type RedisConnection, scanTargets } from "../utils";
 
 export interface ProviderDetectionResult {
   type: QueueProviderType;
@@ -12,23 +12,18 @@ export interface ProviderDetectionResult {
  *
  * BullMQ uses: bull:queueName:meta (metadata keys)
  * Bull uses: bull:queueName:id (direct job ID counter)
+ *
+ * On a cluster every master node is sampled, since each node only holds the
+ * keys for its own slots.
  */
 export async function detectProvider(
-  redis: Redis,
+  redis: RedisConnection,
   prefix: string = "bull",
 ): Promise<ProviderDetectionResult> {
   try {
     // Check for BullMQ meta keys (bull:*:meta)
     const metaPattern = `${prefix}:*:meta`;
-    const [, metaKeys] = await redis.scan(
-      "0",
-      "MATCH",
-      metaPattern,
-      "COUNT",
-      100,
-    );
-
-    if (metaKeys.length > 0) {
+    if (await anyKeyMatches(redis, metaPattern)) {
       return {
         type: "bullmq",
         confidence: "high",
@@ -38,9 +33,7 @@ export async function detectProvider(
 
     // Check for Bull id keys (bull:*:id)
     const idPattern = `${prefix}:*:id`;
-    const [, idKeys] = await redis.scan("0", "MATCH", idPattern, "COUNT", 100);
-
-    if (idKeys.length > 0) {
+    if (await anyKeyMatches(redis, idPattern)) {
       return {
         type: "bull",
         confidence: "high",
@@ -65,4 +58,21 @@ export async function detectProvider(
       detectedFrom: "default",
     };
   }
+}
+
+/**
+ * True when a single SCAN page on any scan target returns a key matching
+ * `pattern`. A sample is enough for detection; discovery does the full walk.
+ */
+async function anyKeyMatches(
+  redis: RedisConnection,
+  pattern: string,
+): Promise<boolean> {
+  for (const node of scanTargets(redis)) {
+    const [, keys] = await node.scan("0", "MATCH", pattern, "COUNT", 100);
+    if (keys.length > 0) {
+      return true;
+    }
+  }
+  return false;
 }

--- a/apps/standalone/src/queue/providers/bull/bull-provider.ts
+++ b/apps/standalone/src/queue/providers/bull/bull-provider.ts
@@ -16,7 +16,6 @@ import type {
   WorkerCount,
 } from "@bullstudio/connect-types";
 import Bull from "bull";
-import Redis from "ioredis";
 import { resolveConfiguredPrefixes } from "../../detection/prefix-discovery";
 import { NotConnectedError } from "../../errors";
 import type {
@@ -27,7 +26,12 @@ import type {
   QueueServiceEventCallbacks,
 } from "../../types";
 import { getProviderCapabilities } from "../../types";
-import { redisReconnectStrategy } from "../../utils";
+import {
+  createRedisConnection,
+  type RedisConnection,
+  redisReconnectStrategy,
+  scanMatching,
+} from "../../utils";
 import { parseQueueNameFromKey } from "../redis-key";
 
 const DEFAULT_PREFIX = "bull";
@@ -37,7 +41,7 @@ export class BullProvider implements QueueService {
 
   private readonly config: QueueServiceConfig;
   private readonly eventCallbacks: QueueServiceEventCallbacks;
-  private connection: Redis | null = null;
+  private connection: RedisConnection | null = null;
   private queues = new Map<string, Bull.Queue>();
   private queueAdapters = new Map<string, QueueAdapter>();
   private _isConnected = false;
@@ -106,8 +110,10 @@ export class BullProvider implements QueueService {
       return;
     }
 
-    this.connection = new Redis(this.config.redisUrl, {
-      maxRetriesPerRequest: null,
+    // Cluster mode (detected by the provider factory) connects with a cluster
+    // client seeded from the URL; single-node mode keeps a plain client.
+    this.connection = createRedisConnection(this.config.redisUrl, {
+      cluster: this.config.cluster,
       enableReadyCheck: true,
       lazyConnect: true,
       // Auto-reconnect with backoff so a dropped connection self-heals once
@@ -399,8 +405,8 @@ export class BullProvider implements QueueService {
           if (type === "client") {
             return connection.duplicate();
           }
-          return new Redis(this.config.redisUrl, {
-            maxRetriesPerRequest: null,
+          return createRedisConnection(this.config.redisUrl, {
+            cluster: this.config.cluster,
             enableReadyCheck: true,
             retryStrategy: redisReconnectStrategy,
           });
@@ -429,26 +435,14 @@ export class BullProvider implements QueueService {
     const seen = new Set<string>();
 
     for (const prefix of prefixes) {
-      const pattern = `${prefix}:*:id`;
-      let cursor = "0";
-      do {
-        const [next, keys] = await this.connection.scan(
-          cursor,
-          "MATCH",
-          pattern,
-          "COUNT",
-          100,
-        );
-        cursor = next;
-        for (const key of keys) {
-          const name = parseQueueNameFromKey(key, prefix, "id");
-          if (!name) continue;
-          const composite = this.queueKey(prefix, name);
-          if (seen.has(composite)) continue;
-          seen.add(composite);
-          result.push({ name, prefix });
-        }
-      } while (cursor !== "0");
+      await scanMatching(this.connection, `${prefix}:*:id`, (key) => {
+        const name = parseQueueNameFromKey(key, prefix, "id");
+        if (!name) return;
+        const composite = this.queueKey(prefix, name);
+        if (seen.has(composite)) return;
+        seen.add(composite);
+        result.push({ name, prefix });
+      });
     }
 
     return result;

--- a/apps/standalone/src/queue/providers/bullmq/bullmq-provider.ts
+++ b/apps/standalone/src/queue/providers/bullmq/bullmq-provider.ts
@@ -16,7 +16,6 @@ import type {
   WorkerCount,
 } from "@bullstudio/connect-types";
 import { Queue } from "bullmq";
-import Redis from "ioredis";
 import { resolveConfiguredPrefixes } from "../../detection/prefix-discovery";
 import { NotConnectedError } from "../../errors";
 import type {
@@ -27,7 +26,12 @@ import type {
   QueueServiceEventCallbacks,
 } from "../../types";
 import { getProviderCapabilities } from "../../types";
-import { redisReconnectStrategy } from "../../utils";
+import {
+  createRedisConnection,
+  type RedisConnection,
+  redisReconnectStrategy,
+  scanMatching,
+} from "../../utils";
 import { parseQueueNameFromKey } from "../redis-key";
 
 const DEFAULT_PREFIX = "bull";
@@ -37,7 +41,7 @@ export class BullMqProvider implements QueueService {
 
   private readonly config: QueueServiceConfig;
   private readonly eventCallbacks: QueueServiceEventCallbacks;
-  private connection: Redis | null = null;
+  private connection: RedisConnection | null = null;
   private queues = new Map<string, Queue>();
   private queueAdapters = new Map<string, QueueAdapter>();
   private _isConnected = false;
@@ -106,8 +110,10 @@ export class BullMqProvider implements QueueService {
       return;
     }
 
-    this.connection = new Redis(this.config.redisUrl, {
-      maxRetriesPerRequest: null,
+    // Cluster mode (detected by the provider factory) connects with a cluster
+    // client seeded from the URL; single-node mode keeps a plain client.
+    this.connection = createRedisConnection(this.config.redisUrl, {
+      cluster: this.config.cluster,
       enableReadyCheck: true,
       lazyConnect: true,
       // Auto-reconnect with backoff so a dropped connection self-heals once
@@ -418,26 +424,14 @@ export class BullMqProvider implements QueueService {
     const seen = new Set<string>();
 
     for (const prefix of prefixes) {
-      const pattern = `${prefix}:*:meta`;
-      let cursor = "0";
-      do {
-        const [next, keys] = await this.connection.scan(
-          cursor,
-          "MATCH",
-          pattern,
-          "COUNT",
-          100,
-        );
-        cursor = next;
-        for (const key of keys) {
-          const name = parseQueueNameFromKey(key, prefix, "meta");
-          if (!name) continue;
-          const composite = this.queueKey(prefix, name);
-          if (seen.has(composite)) continue;
-          seen.add(composite);
-          result.push({ name, prefix });
-        }
-      } while (cursor !== "0");
+      await scanMatching(this.connection, `${prefix}:*:meta`, (key) => {
+        const name = parseQueueNameFromKey(key, prefix, "meta");
+        if (!name) return;
+        const composite = this.queueKey(prefix, name);
+        if (seen.has(composite)) return;
+        seen.add(composite);
+        result.push({ name, prefix });
+      });
     }
 
     return result;

--- a/apps/standalone/src/queue/providers/provider-factory.ts
+++ b/apps/standalone/src/queue/providers/provider-factory.ts
@@ -5,6 +5,11 @@ import type {
   QueueService,
   QueueServiceConfig,
 } from "../types";
+import {
+  createRedisConnection,
+  isClusterEnabled,
+  type RedisConnection,
+} from "../utils";
 import { BullProvider } from "./bull";
 import { BullMqProvider } from "./bullmq";
 
@@ -12,11 +17,15 @@ import { BullMqProvider } from "./bullmq";
  * Auto-detect and create appropriate queue provider.
  * When `prefixes: ["*"]` is set, discovers all
  * prefixes before detecting the provider type.
+ *
+ * Cluster mode is detected from the target Redis itself (`INFO cluster`) and
+ * recorded on the provider config, so providers connect with a cluster client
+ * and discovery fans out across every master node.
  */
 export async function createQueueProvider(
   config: QueueServiceConfig,
 ): Promise<QueueService> {
-  const redis = new Redis(config.redisUrl, {
+  let redis: RedisConnection = new Redis(config.redisUrl, {
     maxRetriesPerRequest: null,
     lazyConnect: true,
     retryStrategy: () => null,
@@ -34,6 +43,22 @@ export async function createQueueProvider(
   try {
     await redis.connect();
 
+    const cluster = await isClusterEnabled(redis);
+    if (cluster) {
+      // Prefix and provider detection SCAN the keyspace, and each cluster
+      // node only returns keys for its own slots — swap the single-node
+      // detection client for a cluster client before scanning.
+      await redis.quit().catch(() => {});
+      redis = createRedisConnection(config.redisUrl, {
+        cluster: true,
+        lazyConnect: true,
+        retryStrategy: () => null,
+      });
+      redis.on("error", () => {});
+      await redis.connect();
+      console.log("[ProviderFactory] Redis Cluster detected");
+    }
+
     let prefixes = config.prefixes;
 
     if (prefixes?.includes("*")) {
@@ -48,7 +73,7 @@ export async function createQueueProvider(
       }
     }
 
-    finalConfig = { ...config, prefixes };
+    finalConfig = { ...config, prefixes, cluster };
 
     const detectionPrefix = prefixes?.[0] ?? config.prefix ?? "bull";
     const detection = await detectProvider(redis, detectionPrefix);

--- a/apps/standalone/src/queue/redis-cluster.test.ts
+++ b/apps/standalone/src/queue/redis-cluster.test.ts
@@ -1,0 +1,100 @@
+import { Queue } from "bullmq";
+import Redis, { Cluster } from "ioredis";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createQueueProvider } from "./providers/provider-factory";
+import { uniquePrefix } from "./test-utils/redis";
+import { isClusterEnabled, parseRedisUrl } from "./utils";
+
+/**
+ * Integration tests against a real Redis Cluster. Skipped unless
+ * TEST_REDIS_CLUSTER_URL points at a cluster node, e.g.:
+ *
+ *   docker run --rm -d -p 7000-7005:7000-7005 -e "IP=0.0.0.0" \
+ *     grokzen/redis-cluster:7.0.10
+ *   TEST_REDIS_CLUSTER_URL=redis://127.0.0.1:7000 pnpm test
+ *
+ * Queues are seeded under hash-tag prefixes (`{tag}`) so each prefix's keys
+ * land on one slot, mirroring how BullMQ is deployed on a cluster.
+ */
+const CLUSTER_URL = process.env.TEST_REDIS_CLUSTER_URL;
+
+describe.skipIf(!CLUSTER_URL)("standalone against a Redis Cluster", () => {
+  const url = CLUSTER_URL as string;
+  const tag = uniquePrefix("bstest");
+  const prefixA = `{${tag}-a}`;
+  const prefixB = `{${tag}-b}`;
+  let cluster: Cluster;
+  let queues: Queue[] = [];
+
+  beforeAll(async () => {
+    const seed = parseRedisUrl(url);
+    cluster = new Cluster([{ host: seed.host, port: seed.port }], {
+      redisOptions: { maxRetriesPerRequest: null },
+    });
+    queues = [
+      new Queue("orders", { connection: cluster, prefix: prefixA }),
+      new Queue("emails", { connection: cluster, prefix: prefixB }),
+    ];
+    await queues[0]?.add("job-a", { i: 0 });
+    await queues[1]?.add("job-b", { i: 1 });
+  });
+
+  afterAll(async () => {
+    for (const queue of queues) {
+      await queue.obliterate({ force: true }).catch(() => {});
+      await queue.close().catch(() => {});
+    }
+    await cluster?.quit().catch(() => {});
+  });
+
+  it("detects cluster mode from a single-node probe", async () => {
+    const probe = new Redis(url, {
+      maxRetriesPerRequest: null,
+      lazyConnect: true,
+      retryStrategy: () => null,
+    });
+    probe.on("error", () => {});
+    await probe.connect();
+    try {
+      expect(await isClusterEnabled(probe)).toBe(true);
+    } finally {
+      await probe.quit().catch(() => {});
+    }
+  });
+
+  it("discovers hash-tag prefixes across all masters via a glob", async () => {
+    const provider = await createQueueProvider({
+      redisUrl: url,
+      prefixes: [`{${tag}-*}`],
+    });
+    await provider.connect();
+    try {
+      expect(await provider.getPrefixes()).toEqual([prefixA, prefixB]);
+
+      const discovered = await provider.getQueues();
+      expect(discovered.map((q) => q.name).sort()).toEqual([
+        "emails",
+        "orders",
+      ]);
+
+      const counts = await provider.getJobCounts("orders", prefixA);
+      expect(counts).toMatchObject({ waiting: 1 });
+    } finally {
+      await provider.disconnect().catch(() => {});
+    }
+  });
+
+  it("discovers the seeded prefixes with full auto-discovery", async () => {
+    const provider = await createQueueProvider({
+      redisUrl: url,
+      prefixes: ["*"],
+    });
+    await provider.connect();
+    try {
+      const prefixes = await provider.getPrefixes();
+      expect(prefixes).toEqual(expect.arrayContaining([prefixA, prefixB]));
+    } finally {
+      await provider.disconnect().catch(() => {});
+    }
+  });
+});

--- a/apps/standalone/src/queue/types/queue-service.types.ts
+++ b/apps/standalone/src/queue/types/queue-service.types.ts
@@ -39,6 +39,8 @@ export interface QueueServiceConfig {
   prefix?: string;
   /** Explicit list of prefixes. Use `["*"]` for auto-discovery. */
   prefixes?: string[];
+  /** Connect with a Redis Cluster client (set by provider detection). */
+  cluster?: boolean;
   eventCallbacks?: QueueServiceEventCallbacks;
 }
 

--- a/apps/standalone/src/queue/utils/index.ts
+++ b/apps/standalone/src/queue/utils/index.ts
@@ -1,1 +1,10 @@
+export {
+  createRedisConnection,
+  isClusterEnabled,
+  parseRedisUrl,
+  type RedisConnection,
+  type RedisConnectionOptions,
+  scanMatching,
+  scanTargets,
+} from "./redis-connection";
 export { redisReconnectStrategy } from "./redis-retry";

--- a/apps/standalone/src/queue/utils/redis-connection.test.ts
+++ b/apps/standalone/src/queue/utils/redis-connection.test.ts
@@ -1,0 +1,104 @@
+import type Redis from "ioredis";
+import { Cluster } from "ioredis";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  createTestRedis,
+  ensureRedisAvailable,
+  flushTestDb,
+  TEST_REDIS_URL,
+} from "../test-utils/redis";
+import {
+  createRedisConnection,
+  isClusterEnabled,
+  parseRedisUrl,
+  scanMatching,
+  scanTargets,
+} from "./redis-connection";
+
+describe("parseRedisUrl", () => {
+  it("parses host and port", () => {
+    expect(parseRedisUrl("redis://redis.example.com:6380")).toMatchObject({
+      host: "redis.example.com",
+      port: 6380,
+      tls: false,
+    });
+  });
+
+  it("defaults the port to 6379", () => {
+    expect(parseRedisUrl("redis://redis.example.com").port).toBe(6379);
+  });
+
+  it("parses credentials", () => {
+    expect(parseRedisUrl("redis://user:secret@localhost:6379")).toMatchObject({
+      username: "user",
+      password: "secret",
+    });
+  });
+
+  it("marks rediss:// URLs as TLS", () => {
+    expect(parseRedisUrl("rediss://localhost:6380").tls).toBe(true);
+  });
+
+  it("ignores the database segment (clusters only support db 0)", () => {
+    expect(parseRedisUrl("redis://localhost:6379/15")).toMatchObject({
+      host: "localhost",
+      port: 6379,
+    });
+  });
+});
+
+describe("createRedisConnection", () => {
+  it("creates a single-node client by default", () => {
+    const connection = createRedisConnection(TEST_REDIS_URL, {
+      lazyConnect: true,
+    });
+    expect(connection).not.toBeInstanceOf(Cluster);
+    connection.disconnect();
+  });
+
+  it("creates a cluster client when cluster is set", () => {
+    const connection = createRedisConnection(TEST_REDIS_URL, {
+      cluster: true,
+      lazyConnect: true,
+    });
+    expect(connection).toBeInstanceOf(Cluster);
+    connection.disconnect();
+  });
+});
+
+describe("scanTargets / scanMatching / isClusterEnabled (single node)", () => {
+  let redis: Redis;
+
+  beforeAll(async () => {
+    await ensureRedisAvailable();
+    redis = createTestRedis();
+  });
+
+  afterAll(async () => {
+    if (!redis) return;
+    await redis.quit().catch(() => {});
+  });
+
+  beforeEach(async () => {
+    await flushTestDb(redis);
+  });
+
+  it("scans the client itself on a single-node connection", () => {
+    expect(scanTargets(redis)).toEqual([redis]);
+  });
+
+  it("collects every key matching the pattern", async () => {
+    await redis.set("stage:q1:meta", "1");
+    await redis.set("stage:q2:meta", "1");
+    await redis.set("other:q3:id", "1");
+
+    const keys: string[] = [];
+    await scanMatching(redis, "stage:*:meta", (key) => keys.push(key));
+
+    expect(keys.sort()).toEqual(["stage:q1:meta", "stage:q2:meta"]);
+  });
+
+  it("reports a single-node Redis as not cluster-enabled", async () => {
+    expect(await isClusterEnabled(redis)).toBe(false);
+  });
+});

--- a/apps/standalone/src/queue/utils/redis-connection.ts
+++ b/apps/standalone/src/queue/utils/redis-connection.ts
@@ -1,0 +1,147 @@
+import Redis, { Cluster } from "ioredis";
+
+/** A standalone-mode Redis client: single-node or cluster. */
+export type RedisConnection = Redis | Cluster;
+
+/** Options shared by single-node and cluster clients built by the factory. */
+export interface RedisConnectionOptions {
+  /** Connect with a cluster client seeded from the Redis URL. */
+  cluster?: boolean;
+  lazyConnect?: boolean;
+  enableReadyCheck?: boolean;
+  commandTimeout?: number;
+  /**
+   * Reconnect backoff, or `() => null` to fail fast. Applied as
+   * `retryStrategy` on single-node clients and `clusterRetryStrategy` on
+   * cluster clients.
+   */
+  retryStrategy?: (attempt: number) => number | null;
+}
+
+/** Cluster seed-node fields parsed from a redis:// or rediss:// URL. */
+export interface ParsedRedisUrl {
+  host: string;
+  port: number;
+  username?: string;
+  password?: string;
+  tls: boolean;
+}
+
+/**
+ * Detect whether the Redis behind `redis` runs in cluster mode by reading
+ * `INFO cluster` (`cluster_enabled:1`). INFO is key-less, so it is safe to
+ * issue from a single-node client connected to a cluster node.
+ */
+export async function isClusterEnabled(
+  redis: RedisConnection,
+): Promise<boolean> {
+  try {
+    const info = await redis.info("cluster");
+    return info.includes("cluster_enabled:1");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Parse a redis:// / rediss:// URL into cluster seed-node fields. The URL's
+ * database segment is ignored: Redis Cluster only supports database 0.
+ */
+export function parseRedisUrl(redisUrl: string): ParsedRedisUrl {
+  const url = new URL(redisUrl);
+  return {
+    host: url.hostname || "localhost",
+    port: url.port ? Number(url.port) : 6379,
+    username: url.username ? decodeURIComponent(url.username) : undefined,
+    password: url.password ? decodeURIComponent(url.password) : undefined,
+    tls: url.protocol === "rediss:",
+  };
+}
+
+/**
+ * Create the standalone connection for `redisUrl`: a `Cluster` client seeded
+ * from the URL when `cluster` is set, a single-node client otherwise. The
+ * cluster client discovers the remaining nodes from the seed.
+ */
+export function createRedisConnection(
+  redisUrl: string,
+  options: RedisConnectionOptions = {},
+): RedisConnection {
+  const { cluster, retryStrategy, lazyConnect, enableReadyCheck } = options;
+  const { commandTimeout } = options;
+
+  if (!cluster) {
+    return new Redis(redisUrl, {
+      maxRetriesPerRequest: null,
+      lazyConnect,
+      enableReadyCheck,
+      commandTimeout,
+      retryStrategy,
+    });
+  }
+
+  const seed = parseRedisUrl(redisUrl);
+  return new Cluster([{ host: seed.host, port: seed.port }], {
+    lazyConnect,
+    clusterRetryStrategy: retryStrategy,
+    redisOptions: {
+      maxRetriesPerRequest: null,
+      username: seed.username,
+      password: seed.password,
+      tls: seed.tls ? {} : undefined,
+      enableReadyCheck,
+      commandTimeout,
+    },
+  });
+}
+
+/**
+ * The clients to SCAN: every master node for a cluster, the client itself
+ * otherwise. Each cluster node only returns keys for its own slots, so
+ * discovery must visit all masters to see the whole keyspace.
+ */
+export function scanTargets(connection: RedisConnection): Redis[] {
+  return connection instanceof Cluster
+    ? connection.nodes("master")
+    : [connection];
+}
+
+const MAX_SCAN_ITERATIONS = 10_000;
+
+/**
+ * SCAN the whole keyspace behind `connection` for keys matching `pattern`,
+ * invoking `onKey` for each match. Fans out across every master node on a
+ * cluster. Each node's cursor is bounded by MAX_SCAN_ITERATIONS as a runaway
+ * guard.
+ */
+export async function scanMatching(
+  connection: RedisConnection,
+  pattern: string,
+  onKey: (key: string) => void,
+): Promise<void> {
+  for (const node of scanTargets(connection)) {
+    let cursor = "0";
+    let iterations = 0;
+    do {
+      const [next, keys] = await node.scan(
+        cursor,
+        "MATCH",
+        pattern,
+        "COUNT",
+        200,
+      );
+      cursor = next;
+      for (const key of keys) {
+        onKey(key);
+      }
+      iterations++;
+      if (iterations >= MAX_SCAN_ITERATIONS) {
+        console.warn(
+          `[RedisConnection] Stopped SCAN after ` +
+            `${MAX_SCAN_ITERATIONS} iterations`,
+        );
+        break;
+      }
+    } while (cursor !== "0");
+  }
+}

--- a/apps/website-with-docs/content/docs/standalone.mdx
+++ b/apps/website-with-docs/content/docs/standalone.mdx
@@ -128,6 +128,23 @@ bullstudio -r redis://username:password@redis.example.com:6379
 bullstudio -r rediss://username:password@redis.example.com:6380
 ```
 
+## Redis Cluster
+
+Cluster mode is detected automatically: point `REDIS_URL` at any cluster node
+and Bullstudio connects with a cluster client seeded from that node,
+discovering the rest of the topology itself. Queue and prefix discovery scans
+every master node, so hash-tag prefixes (e.g. `{orders}`) are found wherever
+their slots live.
+
+```bash
+# any node of the cluster works as the seed
+bullstudio -r redis://cluster-node.example.com:6379
+```
+
+BullMQ on a cluster requires hash-tag prefixes (e.g. `{myapp}`) so each
+queue's keys share a slot; queues written without hash tags may not be
+usable on a cluster regardless of the dashboard.
+
 ## Health check
 
 ```bash


### PR DESCRIPTION
## Problem

Pointing standalone mode at a Redis Cluster shows an empty (or silently partial) dashboard, reported in #8. Every connection was a single-node ioredis client, so `SCAN`-based discovery only saw the connected node's slots, and key operations for other slots failed with `MOVED` redirects.

## Approach

- **Automatic detection, no new configuration.** The provider factory's short-lived probe runs `INFO cluster` (key-less, so safe from a single-node client against a cluster node) and records `cluster: true` on the provider config.
- **Cluster clients seeded from `REDIS_URL`.** A new `createRedisConnection` factory builds either the existing single-node client or an `ioredis.Cluster` seeded from the URL (host/port/credentials/TLS parsed; database segment ignored since clusters only support db 0). Reconnect backoff maps to `clusterRetryStrategy`.
- **Discovery fans out across masters.** A shared `scanMatching` helper SCANs every master node (each node only returns its own slots' keys) and is now used by prefix discovery, provider detection, and both providers' queue discovery. Prefix globs like `{myapp-*}` therefore resolve across the whole keyspace, matching how BullMQ deploys on clusters with hash-tag prefixes.
- BullMQ's `Queue` accepts the cluster connection as-is; Bull's `createClient` non-client types go through the same factory.

## Testing

- `pnpm test` (single-node Redis from `docker-compose.test.yml`): 76 passed, including new unit tests for the connection factory, URL parsing, and scan fan-out. The new cluster suite skips automatically when `TEST_REDIS_CLUSTER_URL` is unset, so CI stays green without a cluster service.
- Cluster integration (`src/queue/redis-cluster.test.ts`) against a local 3-master cluster (`redis-cli --cluster create`, replicas 0): cluster-mode detection from a single-node probe, glob prefix discovery across masters (`{tag-*}` resolving to two hash-tag prefixes living on different nodes), and full `*` auto-discovery all pass.
- `pnpm typecheck` and `biome check` clean on the changed files.

Docs: added a "Redis Cluster" section to the standalone page. Changeset: minor bump for `bullstudio`.

Closes #8
