### PR TITLE
feat: serve the standalone dashboard under a configurable base path

### DIFF
--- a/.changeset/standalone-base-path.md
+++ b/.changeset/standalone-base-path.md
@@ -1,0 +1,5 @@
+---
+"bullstudio": minor
+---
+
+Standalone mode can now serve the dashboard under a path prefix via `BULLSTUDIO_BASE_PATH` (or `--base-path`), for deployments behind path-routing proxies where subdomains are not available (e.g. `example.com/queues`). The UI, assets, login flow, and private dashboard API all mount under the prefix, HTML/CSS asset URLs are rewritten the same way embedded mode does it, and `/health` / `/healthz` remain at the root for container probes (and are also served under the prefix). Root serving is unchanged when no base path is configured.

--- a/apps/standalone/server/standalone.ts
+++ b/apps/standalone/server/standalone.ts
@@ -43,6 +43,7 @@ export interface StandaloneAppOptions {
 
 export function createStandaloneApp(options: StandaloneAppOptions): Hono {
   const env = options.env ?? process.env;
+  const basePath = getStandaloneBasePath(env);
   const app = new Hono();
   const protection = getStandaloneProtection(env);
   const polling = getStandalonePolling(env);
@@ -52,7 +53,7 @@ export function createStandaloneApp(options: StandaloneAppOptions): Hono {
   const dashboard = createStandaloneDashboard({
     protection,
     handleDashboardAsset: (request) =>
-      handleDashboardAsset(request, options.clientDir, polling),
+      handleDashboardAsset(request, options.clientDir, polling, basePath),
     mountPrivateDashboardApi: () => ({
       handle: async (request) => {
         if (!getAuthenticatedSession(protection, request).authenticated) {
@@ -86,47 +87,85 @@ export function createStandaloneApp(options: StandaloneAppOptions): Hono {
   });
   const privateDashboardApi = dashboard.mountPrivateDashboardApi();
 
-  app.get("/health", (c) => healthResponse(c, env));
-  app.get("/healthz", (c) => healthResponse(c, env));
+  // Health stays at the root for container probes and is also served under
+  // the base path so proxied health checks work.
+  const healthPaths = basePath
+    ? ["/health", "/healthz", `${basePath}/health`, `${basePath}/healthz`]
+    : ["/health", "/healthz"];
+  for (const path of healthPaths) {
+    app.get(path, (c) => healthResponse(c, env));
+  }
 
-  app.all("/api/auth/*", async (c) =>
+  app.all(`${basePath}/api/auth/*`, async (c) =>
     toHonoResponse(
       await dashboard.handle({
         method: c.req.method,
-        url: c.req.url,
+        url: toMountedUrl(c.req.url, basePath),
         headers: c.req.raw.headers,
         body: await c.req.text(),
-        basePath: "/",
+        basePath: basePath || "/",
       }),
     ),
   );
 
-  app.all("/api/trpc/*", async (c) =>
+  app.all(`${basePath}/api/trpc/*`, async (c) =>
     toHonoResponse(
       await privateDashboardApi.handle({
         method: c.req.method,
-        url: c.req.url,
+        url: toMountedUrl(c.req.url, basePath),
         headers: c.req.raw.headers,
         body: c.req.raw.body,
-        basePath: "/",
+        basePath: basePath || "/",
       }),
     ),
   );
 
-  app.on(["GET", "HEAD"], "*", async (c) =>
-    toHonoResponse(
-      await dashboard.handle({
+  // `${basePath}/*` does not match the bare base path, so register both.
+  app.on(["GET", "HEAD"], basePath ? [basePath, `${basePath}/*`] : ["*"], (c) =>
+    dashboard
+      .handle({
         method: c.req.method,
-        url: c.req.url,
+        url: toMountedUrl(c.req.url, basePath),
         headers: c.req.raw.headers,
-        basePath: "/",
-      }),
-    ),
+        basePath: basePath || "/",
+      })
+      .then(toHonoResponse),
   );
 
   app.notFound((c) => c.text("Not Found", 404));
 
   return app;
+}
+
+/**
+ * Base path the dashboard is served under (e.g. behind a path-routing proxy).
+ * Empty string means the root, preserving default behaviour.
+ */
+function getStandaloneBasePath(env: StandaloneAppOptions["env"]): string {
+  const raw = env?.BULLSTUDIO_BASE_PATH;
+
+  if (!raw || raw === "/") {
+    return "";
+  }
+
+  return `/${raw.replace(/^\/+|\/+$/g, "")}`;
+}
+
+/** Strip the base path from a request URL so downstream handlers see "/". */
+function toMountedUrl(url: string, basePath: string): string {
+  if (!basePath) {
+    return url;
+  }
+
+  const parsedUrl = new URL(url);
+
+  if (parsedUrl.pathname === basePath) {
+    parsedUrl.pathname = "/";
+  } else if (parsedUrl.pathname.startsWith(`${basePath}/`)) {
+    parsedUrl.pathname = parsedUrl.pathname.slice(basePath.length);
+  }
+
+  return parsedUrl.toString();
 }
 
 function getStandaloneProtection(
@@ -200,6 +239,7 @@ async function handleDashboardAsset(
   request: { method: string; url: string },
   clientDir: string,
   polling: PollingConfig | undefined,
+  basePath: string,
 ): Promise<FrameworkResponse> {
   const pathname = new URL(request.url).pathname;
   const staticFilePath = getStaticFilePath(pathname, clientDir);
@@ -217,6 +257,7 @@ async function handleDashboardAsset(
         staticFilePath,
         cacheControl,
         polling,
+        basePath,
       );
     }
   }
@@ -226,6 +267,7 @@ async function handleDashboardAsset(
     join(clientDir, "index.html"),
     "no-cache",
     polling,
+    basePath,
   );
 }
 
@@ -260,14 +302,18 @@ async function getFileResponse(
   filePath: string,
   cacheControl: string,
   polling: PollingConfig | undefined,
+  basePath: string,
 ): Promise<FrameworkResponse> {
   const ext = extname(filePath);
   const contentType = MIME_TYPES[ext] || "application/octet-stream";
 
-  // HTML is the only asset that carries runtime config, so it's served as a
-  // (possibly rewritten) string. Everything else is streamed as-is.
+  // HTML carries runtime config and base-path rewrites, CSS carries base-path
+  // rewrites, so both are served as strings. Everything else streams as-is.
   if (ext === ".html") {
-    const html = injectRuntimeConfig(await readFile(filePath, "utf8"), polling);
+    const html = rewriteHtmlBasePath(
+      injectRuntimeConfig(await readFile(filePath, "utf8"), polling, basePath),
+      basePath,
+    );
     const headers = {
       "Cache-Control": cacheControl,
       "Content-Length": Buffer.byteLength(html).toString(),
@@ -278,6 +324,25 @@ async function getFileResponse(
       status: 200,
       headers,
       body: method === "HEAD" ? undefined : html,
+    };
+  }
+
+  if (ext === ".css" && basePath) {
+    // Mirrors embedded-core's readAssetFile CSS rewrite
+    const css = (await readFile(filePath, "utf8")).replaceAll(
+      "url(/assets/",
+      `url(${basePath}/assets/`,
+    );
+    const headers = {
+      "Cache-Control": cacheControl,
+      "Content-Length": Buffer.byteLength(css).toString(),
+      "Content-Type": contentType,
+    };
+
+    return {
+      status: 200,
+      headers,
+      body: method === "HEAD" ? undefined : css,
     };
   }
 
@@ -302,18 +367,22 @@ async function getFileResponse(
   };
 }
 
-// Merge env-derived polling config into `window.__BULLSTUDIO__` without
-// clobbering anything the build may have set. Mirrors embedded-core's
+// Merge env-derived config (base path, polling) into `window.__BULLSTUDIO__`
+// without clobbering anything the build may have set. Mirrors embedded-core's
 // escapeScriptJson so the `<` escape keeps the inline script safe.
 function injectRuntimeConfig(
   html: string,
   polling: PollingConfig | undefined,
+  basePath: string,
 ): string {
-  if (!polling) {
+  if (!polling && !basePath) {
     return html;
   }
 
-  const runtimeConfig = JSON.stringify({ polling }).replace(/</g, "\\u003c");
+  const runtimeConfig = JSON.stringify({
+    ...(basePath ? { basePath } : {}),
+    ...(polling ? { polling } : {}),
+  }).replace(/</g, "\\u003c");
   const script = `<script>window.__BULLSTUDIO__=Object.assign({},window.__BULLSTUDIO__,${runtimeConfig});</script>`;
 
   if (html.includes("</head>")) {
@@ -321,6 +390,18 @@ function injectRuntimeConfig(
   }
 
   return `${script}${html}`;
+}
+
+// Mirrors embedded-core's renderDashboardHtml asset rewrites for a base path
+function rewriteHtmlBasePath(html: string, basePath: string): string {
+  if (!basePath) {
+    return html;
+  }
+
+  return html
+    .replaceAll('href="/assets/', `href="${basePath}/assets/`)
+    .replaceAll('src="/assets/', `src="${basePath}/assets/`)
+    .replaceAll('href="/logo.svg"', `href="${basePath}/logo.svg"`);
 }
 
 function toFetchRequest(request: {

--- a/apps/standalone/src/standalone-base-path.test.ts
+++ b/apps/standalone/src/standalone-base-path.test.ts
@@ -1,0 +1,124 @@
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Hono } from "hono";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+  vi.doUnmock("./connection");
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+const INDEX_HTML =
+  "<!doctype html><html><head>" +
+  '<link rel="icon" href="/logo.svg">' +
+  '<link rel="stylesheet" href="/assets/app.css">' +
+  '<script src="/assets/app.js"></script>' +
+  "</head><body></body></html>";
+
+async function createClientDir(): Promise<string> {
+  const clientDir = await mkdtemp(join(tmpdir(), "bullstudio-base-path-"));
+  await mkdir(join(clientDir, "assets"), { recursive: true });
+  await writeFile(join(clientDir, "index.html"), INDEX_HTML);
+  await writeFile(join(clientDir, "assets", "app.js"), "console.log(1);");
+  await writeFile(
+    join(clientDir, "assets", "app.css"),
+    "body{background:url(/assets/bg.png)}",
+  );
+  return clientDir;
+}
+
+async function createApp(env: NodeJS.ProcessEnv): Promise<Hono> {
+  vi.doMock("./connection", () => ({
+    disconnectProvider: async () => {},
+    getQueueProvider: async () => ({
+      cluster: false,
+      getCapabilities: () => ({
+        providerType: "bullmq",
+        supportsFlows: true,
+        supportedJobStates: [],
+      }),
+      getPrefixes: async () => ["bull"],
+      getQueues: async () => [],
+      isConnected: () => true,
+    }),
+  }));
+
+  const { createStandaloneApp } = await import("../server/standalone");
+  return createStandaloneApp({ clientDir: await createClientDir(), env });
+}
+
+describe("standalone base path", () => {
+  it("serves the dashboard at the base path with rewritten asset URLs", async () => {
+    const app = await createApp({ BULLSTUDIO_BASE_PATH: "/queues" });
+
+    const response = await app.request("/queues");
+    expect(response.status).toBe(200);
+
+    const html = await response.text();
+    expect(html).toContain('src="/queues/assets/app.js"');
+    expect(html).toContain('href="/queues/assets/app.css"');
+    expect(html).toContain('href="/queues/logo.svg"');
+    expect(html).toContain('"basePath":"/queues"');
+  });
+
+  it("normalizes a base path without a leading slash or with a trailing slash", async () => {
+    const app = await createApp({ BULLSTUDIO_BASE_PATH: "queues/" });
+
+    const response = await app.request("/queues");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain('"basePath":"/queues"');
+  });
+
+  it("serves static assets under the base path", async () => {
+    const app = await createApp({ BULLSTUDIO_BASE_PATH: "/queues" });
+
+    const response = await app.request("/queues/assets/app.js");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("console.log(1);");
+  });
+
+  it("rewrites CSS url() references against the base path", async () => {
+    const app = await createApp({ BULLSTUDIO_BASE_PATH: "/queues" });
+
+    const response = await app.request("/queues/assets/app.css");
+    expect(response.status).toBe(200);
+    expect(await response.text()).toContain("url(/queues/assets/bg.png)");
+  });
+
+  it("keeps health at the root for probes and serves it under the base path", async () => {
+    const app = await createApp({ BULLSTUDIO_BASE_PATH: "/queues" });
+
+    expect((await app.request("/health")).status).toBe(200);
+    expect((await app.request("/queues/health")).status).toBe(200);
+  });
+
+  it("mounts the private dashboard API under the base path", async () => {
+    const app = await createApp({ BULLSTUDIO_BASE_PATH: "/queues" });
+
+    const response = await app.request(
+      "/queues/api/trpc/connection.info,queues.list?batch=1",
+      { headers: { "trpc-accept": "application/jsonl" } },
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it("returns 404 outside the base path", async () => {
+    const app = await createApp({ BULLSTUDIO_BASE_PATH: "/queues" });
+
+    expect((await app.request("/")).status).toBe(404);
+    expect((await app.request("/assets/app.js")).status).toBe(404);
+  });
+
+  it("keeps root serving unchanged when no base path is configured", async () => {
+    const app = await createApp({});
+
+    const response = await app.request("/");
+    expect(response.status).toBe(200);
+
+    const html = await response.text();
+    expect(html).toContain('src="/assets/app.js"');
+    expect(html).not.toContain("__BULLSTUDIO__");
+  });
+});

--- a/apps/website-with-docs/content/docs/standalone.mdx
+++ b/apps/website-with-docs/content/docs/standalone.mdx
@@ -37,6 +37,7 @@ bullstudio \
 | `--redis <url>` | `-r` | Redis connection URL. |
 | `--port <port>` | `-p` | HTTP port. |
 | `--prefix <prefixes>` | | Comma-separated Redis key prefixes. Omit to auto-discover. |
+| `--base-path <path>` | | Serve the dashboard under a path prefix (e.g. `/queues`). |
 | `--username <user>` | | Dashboard login username when auth is enabled. |
 | `--password <pass>` | | Enables dashboard login. |
 | `--no-open` | | Do not open the browser automatically. |
@@ -57,6 +58,7 @@ bullstudio
 | `REDIS_URL` | Redis connection URL. |
 | `PORT` | HTTP port. |
 | `REDIS_PREFIX` | Comma-separated Redis key prefixes. |
+| `BULLSTUDIO_BASE_PATH` | Serve the dashboard under a path prefix (e.g. `/queues`). |
 | `BULLSTUDIO_USERNAME` | Login username when `BULLSTUDIO_PASSWORD` is set. |
 | `BULLSTUDIO_PASSWORD` | Enables dashboard login. |
 | `BULLSTUDIO_POLL_ENABLED` | Set to `false` to disable polling entirely. |
@@ -146,6 +148,22 @@ this with either a hash-tagged prefix, such as `prefix: "{myprefix}"`, or a
 hash-tagged queue name, such as `new Queue("{cluster}")`. For multiple queues,
 use distinct hash tags or prefixes so their slots can be distributed across
 the cluster's masters.
+
+## Serve under a path
+
+To expose the dashboard on a path of an existing host (e.g. behind a reverse
+proxy routing `example.com/queues`), set a base path. The UI, its assets, the
+login flow, and the private dashboard API all move under the prefix; requests
+outside it return 404.
+
+```bash
+bullstudio -r redis://localhost:6379 --base-path /queues
+# or: BULLSTUDIO_BASE_PATH=/queues bullstudio -r redis://localhost:6379
+```
+
+Point the proxy route at the server without stripping the prefix. `/health`
+and `/healthz` stay available at the root for container probes and are also
+served under the base path for proxied health checks.
 
 ## Health check
 

--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -42,6 +42,10 @@ const { values, positionals } = parseArgs({
       description:
         "Redis key prefix(es), comma-separated (default: auto-discover)",
     },
+    "base-path": {
+      type: "string",
+      description: "Base path to serve the dashboard under (e.g. /queues)",
+    },
     "no-open": {
       type: "boolean",
       description: "Do not open browser automatically",
@@ -66,6 +70,7 @@ Options:
   -r, --redis <url>      Redis connection URL (default: redis://localhost:6379)
   -p, --port <port>      Port to run the server on (default: 4000)
   --prefix <prefixes>    Comma-separated key prefixes (default: auto-discover all)
+  --base-path <path>     Serve the dashboard under a path prefix (e.g. /queues)
   --username <user>      Username for HTTP Basic Auth (default: bullstudio)
   --password <pass>      Password for HTTP Basic Auth
   --no-open              Do not open browser automatically
@@ -91,6 +96,7 @@ const isDev = values.dev;
 const username = values.username;
 const password = values.password;
 const prefixArg = values.prefix;
+const basePathArg = values["base-path"];
 
 // Validate Redis URL
 try {
@@ -161,6 +167,7 @@ if (isDev) {
       PORT: port,
       BULLSTUDIO_CLIENT_DIR: clientDir,
       ...(prefixArg ? { REDIS_PREFIX: prefixArg } : {}),
+      ...(basePathArg ? { BULLSTUDIO_BASE_PATH: basePathArg } : {}),
     },
     stdio: "pipe",
     shell: true,
@@ -179,6 +186,7 @@ if (isDev) {
       BULLSTUDIO_USERNAME: username,
       BULLSTUDIO_PASSWORD: password,
       ...(prefixArg ? { REDIS_PREFIX: prefixArg } : {}),
+      ...(basePathArg ? { BULLSTUDIO_BASE_PATH: basePathArg } : {}),
     },
     stdio: "pipe",
   });


### PR DESCRIPTION
## Problem

Standalone mode always serves at the host root. Behind path-routing proxies where a dedicated subdomain is not available (e.g. multi-tenant setups where subdomains are tenant identifiers, exposing the dashboard as `example.com/queues`), the prebuilt HTML/CSS reference absolute `/assets` URLs and the API mounts at `/api/*`, so the UI cannot be served under a prefix.

## Approach

New `BULLSTUDIO_BASE_PATH` env var and `--base-path` CLI flag, mirroring what the framework adapters already do for embedded mode:

- Routes (`/api/auth/*`, `/api/trpc/*`, the asset catch-all) mount under the prefix; the prefix is stripped from request URLs before delegating (same shape as `@bullstudio/hono`'s `toMountedUrl`), so everything downstream is unchanged.
- The standalone asset pipeline applies the same rewrites as embedded-core's `renderDashboardHtml`/`readAssetFile`: HTML `href`/`src` asset URLs, `logo.svg`, CSS `url(/assets/…)`, and `window.__BULLSTUDIO__.basePath` — which the frontend already honours mode-independently (`getBasePath()` in `runtime-config.ts`), so no frontend changes.
- `/health` and `/healthz` stay at the root for container probes and are also served under the prefix for proxied health checks.
- No base path configured → behaviour is unchanged (routes and served bytes identical).

## Testing

- `pnpm test`: 82 passed (8 new tests covering serving at the prefix with rewritten HTML/CSS, static assets under the prefix, tRPC mounted under the prefix, root+prefixed health, 404 outside the prefix, path normalisation, and unchanged root behaviour without a base path).
- `pnpm typecheck` and `biome check` clean on the changed files.

Docs: CLI option + env var tables and a "Serve under a path" section on the standalone page. Changeset: minor bump for `bullstudio`.